### PR TITLE
Enabling Presentation Pointers to Control Forward/Backward

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -226,10 +226,11 @@
     // EVENTS
     
     document.addEventListener("keydown", function ( event ) {
-        if ( event.keyCode == 9 || event.keyCode == 32 || (event.keyCode >= 37 && event.keyCode <= 40) ) {
+        if ( event.keyCode == 9 || ( event.keyCode >= 32 && event.keyCode <= 34 ) || (event.keyCode >= 37 && event.keyCode <= 40) ) {
             var active = $(".step.active", impress);
             var next = active;
             switch( event.keyCode ) {
+                case 33: ; // pg up
                 case 37: ; // left
                 case 38:   // up
                          next = steps.indexOf( active ) - 1;
@@ -237,6 +238,7 @@
                          break;
                 case 9:  ; // tab
                 case 32: ; // space
+                case 34: ; // pg down
                 case 39: ; // right
                 case 40:   // down
                          next = steps.indexOf( active ) + 1;
@@ -249,6 +251,7 @@
             event.preventDefault();
         }
     }, false);
+
     
     // Sometimes it's possible to trigger focus on first link with some keyboard action.
     // Browser in such a case tries to scroll the page to make this element visible


### PR DESCRIPTION
Adding page up and page down key presses for moving forward & backwards on slides because pointers (such as the Logitech R800 I tested with) emulate those key strokes for forward/back.
