### PR TITLE
Add click handler for internal linking between slides

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -254,8 +254,7 @@
 
     document.addEventListener("click", function ( event ) {
         if(event.target.tagName.toUpperCase() == "A" && event.target.className.indexOf('impress-link') >= 0){
-            var link = event.target.getAttribute('href');
-            select($(link));
+            select($(event.target.getAttribute('href')));
             event.preventDefault();
         }
     }, false);


### PR DESCRIPTION
Love impress.js.  I had a use case where I needed to link internally between slides rather than just the previous/next functionality

Added an eventListener to handle click events.  Allows users to link internally between slides.  Links can be written in standard format for internal links, i.e. &lt;a href="#someID" class="impress-link"&gt;Go to SomeID&lt;/a&gt;

Links must have "impress-link" class.  The new function uses the already defined $ selector function so the href can actually be any valid selector, not just an id.  Also uses the already defined select() function.  

The code to implement this functionality is incredibly short and I think other uses would find it a good addition to impress.
