### PR TITLE
Fixed an issue with `select` being called twice on every navigation.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -312,10 +312,6 @@
         return byId( window.location.hash.replace(/^#\/?/,"") );
     }
     
-    window.addEventListener("hashchange", function () {
-        select( getElementFromUrl() );
-    }, false);
-    
     // START 
     // by selecting step defined in url or first step of the presentation
     select(getElementFromUrl() || steps[0]);


### PR DESCRIPTION
This might relate to issue #46. Select was being called twice every time I navigated. I noticed a bit of jumpiness that seems to be better with this code removed.

There might be a good reason you have this code that I hadn't considered, but I couldn't figure it out. It seemed extraneous.
