### PR TITLE
Implemented a simple API for intercepting navigation.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -11,6 +11,12 @@
 
 (function ( document, window ) {
 
+    // API
+    var Impress = window.Impress || {
+		beforeNavigation: function() {}, 
+		afterNavigation: function() {}
+    };
+
     // HELPER FUNCTIONS
     
     var pfx = (function () {
@@ -192,6 +198,9 @@
             return false;
         }
         
+        var before = active;
+        Impress.beforeNavigation(before, el);
+
         // Sometimes it's possible to trigger focus on first link with some keyboard action.
         // Browser in such a case tries to scroll the page to make this element visible
         // (even that body overflow is set to hidden) and it breaks our careful positioning.
@@ -251,6 +260,8 @@
         current = target;
         active = el;
         
+        Impress.afterNavigation(before, active);
+
         return el;
     }
     


### PR DESCRIPTION
This is a really simple API just for navigation. I know you probably want to do a lot more than this, but I thought I'd submit the simplest thing that would work and this is all I need right now. :)

This change allows developers to provide custom code that runs when navigating from one step to the next. The following is an example of how a navigation handler might be setup within the top of the html page of the presentation.

```
<script>
    window.Impress = {
        beforeNavigation: function(before, next) {
            if (before != null && before.id == 'slide-1' && next.id == 'slide-2') {
                alert('yes!');
            }
        },
        afterNavigation: function(before, current) {}
    };
</script>
```

Each method provides the before element and the element we're navigating to. This allows the developer to determine whether they're moving forward or backward. But also lets them transition out the old element and transition the new one if need be.
