### PR TITLE
Fixes `select` being called twice.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -186,6 +186,17 @@
 
     var active = null;
     
+    var navigate = function ( el ) {
+		if ( !el || !el.stepData ) {
+            // selected element is not defined as step
+            return false;
+        }
+        
+		// `#/step-id` is used instead of `#step-id` to prevent default browser
+        // scrolling to element in hash
+        window.location.hash = "#/" + el.id;
+    }
+    
     var select = function ( el ) {
         if ( !el || !el.stepData ) {
             // selected element is not defined as step
@@ -210,10 +221,6 @@
         el.classList.add("active");
         
         impress.className = "step-" + el.id;
-        
-        // `#/step-id` is used instead of `#step-id` to prevent default browser
-        // scrolling to element in hash
-        window.location.hash = "#/" + el.id;
         
         var target = {
             rotate: {
@@ -276,7 +283,7 @@
                          break; 
             }
             
-            select(next);
+            navigate(next);
             
             event.preventDefault();
         }


### PR DESCRIPTION
I took a different approach than what we discussed earlier.

The `select` method used to change the hash url which would trigger the 'hashchange' event listener and call `select` again. I refactored the code so that the keyboard and click events change the hash only (by calling a new `navigate` method). This in turns causes the navigation event to occur.

This way, `select` really is only called once.
