### PR TITLE
Byways with Impress.js

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -262,16 +262,24 @@
                 case 33: ; // pg up
                 case 37: ; // left
                 case 38:   // up
-                         next = steps.indexOf( active ) - 1;
-                         next = next >= 0 ? steps[ next ] : steps[ steps.length-1 ];
+                         if ( active.dataset.previous ) {
+                             next = byId( active.dataset.previous );
+                         } else {
+                             next = steps.indexOf( active ) - 1;
+                             next = next >= 0 ? steps[ next ] : steps[ steps.length-1 ];
+                         }
                          break;
                 case 9:  ; // tab
                 case 32: ; // space
                 case 34: ; // pg down
                 case 39: ; // right
                 case 40:   // down
-                         next = steps.indexOf( active ) + 1;
-                         next = next < steps.length ? steps[ next ] : steps[ 0 ];
+                         if ( active.dataset.next ) {
+                             next = byId( active.dataset.next );
+                         } else {
+                             next = steps.indexOf( active ) + 1;
+                             next = next < steps.length ? steps[ next ] : steps[ 0 ];
+                         }
                          break; 
             }
             


### PR DESCRIPTION
With this commit you can set the id of the next or of the previous slide, so impress.js can have byways. 

For example if you can explain featureX, but your listeners perhaps know it or not, so the main line can be `page1 -> page2 -> page3`. If your listeners don't know it, you can show it, and a byway can be: `page1 -> feature1..featureN -> page2 -> as before.`

You must set this settings:

* previous slide of `page1` is `overview`
* next slide of `overview` is `page1`
* previous slide of `feature1` is `page1`
* next slide of `featureN` is `page2`

You can test it at http://farkas-mate.hu/2012/impress-js/

(This pull request is identical to #58, I accidentaly deleted my old branch)