### PR TITLE
Set custom transition duration

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -210,6 +210,21 @@
         
         impress.className = "step-" + el.id;
         
+        var target = {
+            rotate: {
+                x: -parseInt(step.rotate.x, 10),
+                y: -parseInt(step.rotate.y, 10),
+                z: -parseInt(step.rotate.z, 10)
+            },
+            translate: {
+                x: -step.translate.x,
+                y: -step.translate.y,
+                z: -step.translate.z
+            },
+            scale: 1 / parseFloat(step.scale),
+            transitionDuration: step.transitionDuration
+        };
+        
         // if presentation starts (nothing is active yet)
         // don't animate (set duration to 0)
         // transition duration depends on the current direction
@@ -226,21 +241,6 @@
         hashTimeout = window.setTimeout(function () {
             window.location.hash = "#/" + el.id;
         }, duration);
-        
-        var target = {
-            rotate: {
-                x: -parseInt(step.rotate.x, 10),
-                y: -parseInt(step.rotate.y, 10),
-                z: -parseInt(step.rotate.z, 10)
-            },
-            translate: {
-                x: -step.translate.x,
-                y: -step.translate.y,
-                z: -step.translate.z
-            },
-            scale: 1 / parseFloat(step.scale),
-            transitionDuration: step.transitionDuration
-        };
         
         // check if the transition is zooming in or not
         var zoomin = target.scale >= current.scale;


### PR DESCRIPTION
I think it would be a nice idea to have the possibility of defining the transition time between slides. The '1s' default time it may be too much in certain situations.

So i defined a new data attribute "data-transition-duration" which by default is 1000ms (same as now).

``` html
<div class="step">
    <p>Step one!</p>
</div>

<div class="step" data-transition-duration="500">
    <p>Step two!</p>
</div>

<div class="step">
    <p>Step three!</p>
</div>
```

Here we want that the transition time between steps 1 and 2 to be 500ms. And of course, transition time between 2 and 1 should also be 500ms (that's why we have to know if we are moving forward or backwards, because the transition-duration property is only defined once)
