### PR TITLE
Use strict mode

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -10,6 +10,7 @@
  */
 
 (function ( document, window ) {
+    'use strict';
 
     // HELPER FUNCTIONS
     


### PR DESCRIPTION
impress.js is addressed only for modern browsers which support strict mode.

There's currently no tests for impress.js, and strict mode can be very helpful in exposing some errors instantly during development.
