### PR TITLE
Refactored impress.js into an object while maintaining backward-compatibility with v0.3

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -15,18 +15,23 @@
  *  source:  http://github.com/bartaz/impress.js/
  */
 
+// Usage:
+//
+// | var i = new impress();
+// | i.start();
+//
 function impress() {
   // Added for backwards compatibility. If we're not being constructed as an object, behave like the old impress()
   // function.
   if (this.constructor != impress) {
-        var i = new impress();
-        i.start();
-        return {
-          goto: i.goto,
-          next: i.next,
-          prev: i.prev
-        };
-    }
+    var i = new impress();
+    i.start();
+    return {
+      goto: i.goto,
+      next: i.next,
+      prev: i.prev
+    };
+  }
   var self = this;
 
   // Change these before calling start() to alter the presentation configuration
@@ -63,14 +68,23 @@ function impress() {
   self.steps = null;          // Once the presentation has started, this will contain the processed slide data
   self.active_index = null;
   self.hashTimeout = null;
+  // Check for browser support
+  self.supported = (setBrowserSpecificProperty("perspective") != null) &&
+                   (document.body.classList) &&
+                   (document.body.dataset) &&
+                   (navigator.userAgent.toLowerCase().search(/(iphone)|(ipod)|(android)/) == - 1);
 
-  // Pans to the slide specified by index_or_id, which is either a css ID or an index into self.steps
-  self.goto = function(index_or_id) {
-    var index = index_or_id;
+  // Pans to the slide specified by index_or_id, which is either a css ID, step element, or an index into self.steps
+  self.goto = function(index_el_or_id) {
+    var index = index_el_or_id;
 
     // If we were passed a string (an id), convert it the index of the slide to go to
-    if (typeof index_or_id === "string") {
-      var el = self.steps.filter(function(e){return e.node.id == index_or_id;});
+    if (typeof index_el_or_id === "string") {
+      var el = self.steps.filter(function(e){return e.node.id == index_el_or_id;});
+      if (el && el.length > 0)
+        index = self.steps.indexOf(el[0]);
+    } else if (index_el_or_id instanceof HTMLElement) {
+      var el = self.steps.filter(function(e){return e.node == index_el_or_id;});
       if (el && el.length > 0)
         index = self.steps.indexOf(el[0]);
     }
@@ -216,13 +230,7 @@ function impress() {
     return " scale(" + s + ") ";
   };
 
-  // Check for browser support
-  self.supported = (setBrowserSpecificProperty("perspective") != null) &&
-                   (document.body.classList) &&
-                   (document.body.dataset) &&
-                   (navigator.userAgent.toLowerCase().search(/(iphone)|(ipod)|(android)/) == - 1);
-
-  // Call this to begin the impress presentation
+    // Call this to begin the impress presentation
   self.start = function() {
 
     // Only allow a single presentation at a time
@@ -374,4 +382,4 @@ function impress() {
       }
     }, false);
   }
-};
+}


### PR DESCRIPTION
I refactored the impress.js source into an object with a couple of goals:
- Easier to extend and customize
- More concise source
- More comments in the source
- Backwards compatibility

I've managed to shave ~40 lines of code while (in my opinion at least) enhancing readability. The new impress function can either be constructed with `new impress()` in which case most CSS styles and parameters can be customized before beginning the presentation, or if simply called using `impress()` should return the same API you provided in v0.3. This is an enormous refactoring, I understand, so if you don't want to accept such a large pull request no worries at all, this was largely for my own use. I thought I'd offer my changes back in case anybody else is interested. Impress.js is fantastic, by the way. I'm really looking forward to seeing the kinds of presentations and websites that come out of tools like impress.js.

Keep up the fantastic work and let me know if you'd like to integrate my changes but would like me to make any more modifications first,
James
