### PR TITLE
freely positioned elements

### DIFF
--- a/css/impress-demo.css
+++ b/css/impress-demo.css
@@ -181,6 +181,17 @@ a:focus {
 }
 
 /*
+    Styling for the freely-positioned elements.
+    We'll style them the same as the slide elements for consistency
+*/
+.positioned {
+    
+    font-family: 'PT Serif', georgia, serif;
+    font-size: 48px;
+    line-height: 1.5;
+}
+
+/*
     ... and we enhance the styles for impress.js.
     
     Basically we remove the margin and make inactive steps a little bit transparent.
@@ -525,6 +536,16 @@ a:focus {
 .impress-on-overview .step {
     opacity: 1;
     cursor: pointer;
+}
+
+/*
+    For the freely-positioned element we will allocate some more space and make the text a bit tighter.
+    Since this text isn't visible on any slide, we can leave it fully opaque all the time.
+*/
+#roamfree {
+    line-height: 1.2em;
+    width: 8em;
+    font-size: 64px;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -312,6 +312,21 @@
     <div id="overview" class="step" data-x="3000" data-y="1500" data-scale="10">
     </div>
 
+    <!--
+    
+        Did you notice this element in the presentation?
+        It is not positioned in any of the slides, but only visible in the overview slide.
+
+        By setting the class to include `positioned`, you can let impress.js know that the element should be
+        put onto the canvas in the place determined by the parameters. All of the positioning parameters work exactly
+        as the ones for the steps, i.e. you can do `data-x`, `data-y`, `data-z`, `data-rotate`, `data-rotate-z`,
+       `data-rotate-x`, `data-rotate-y` and `scale`.
+    
+    -->
+    <div id="roamfree" class="positioned" data-x="-1400" data-y="4000" data-rotate="" data-scale="5">
+      By the way: did you notice that you can also position elements freely without creating a slide?
+    </div>
+    
 </div>
 
 <!--


### PR DESCRIPTION
This pull-request contains two distinct change sets:
1. Pulling the "canvas" apart from the "root" elements to make insertion of additional content into the root element easier. This can be used to put the fallback message or other control elements inside the root-div, making the markup cleaner.
2. Freely positioned elements: These elements are marked with the class "positioned" and will be positioned like steps, but do not show up in the steps list. They can be used to add additional content that is not tied into a single frame, e.g. a graph connecting several steps.
