### PR TITLE
Fix flickering with some 3D transforms in Firefox

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -383,6 +383,11 @@
             });
             css(canvas, rootStyles);
             
+            // preserve-3d on all elements. Fixes flickering with 3d transforms in Firefox.
+            arrayify( root.getElementsByTagName( '*' ) ).forEach(function( el ) {
+                css( el, { transformStyle: 'preserve-3d' } );
+            });
+            
             body.classList.remove("impress-disabled");
             body.classList.add("impress-enabled");
             


### PR DESCRIPTION
Add transform-style: preserve-3d to all elements that might have 3D
transforms on them (potentially all descendants of root)
