### PR TITLE
Add component.json file for bower package manager support.

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,4 +2,18 @@
   "name": "impress-js",
   "version": "0.5.3",
   "main": "./js/impress.js",
+  "description": "It's a presentation framework based on the power of CSS3 transforms and transitions in modern browsers and inspired by the idea behind prezi.com",
+  "homepage": "https://github.com/bartaz/impress.js",
+  "license" : ["http://bartaz.mit-license.org/", "http://www.gnu.org/licenses/"],
+  "main": [
+    "./js/impress.js",
+  ],
+  "keywords": [
+    "slideshow",
+    "css3"
+  ],
+  "author": {
+    "name": "Bartek Szopka",
+    "web": "http://bartaz.github.com"
+  }
 }


### PR DESCRIPTION
[Bower](http://github.com/twitter/bower) is a new package manager for client side libraries and tools and I think it would be great if impress.js was available in Bower's registry.

This would allow impress.js to be added to any project with a single command:

```
bower install impress-js
```
