### PR TITLE
Add optional support for writing slides with markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
         
     -->
     <div id="bored" class="step slide" data-x="-1000" data-y="-1500">
-        <q>Aren't you just <b>bored</b> with all those slides-based presentations?</q>
+        # Aren't you just **bored** with all those slides-based presentations?
     </div>
 
     <!--
@@ -360,6 +360,7 @@ if ("ontouchstart" in document.documentElement) {
     Of course you can wrap it in any kind of "DOM ready" event, but I was too lazy to do so ;)
     
 -->
+<script src="js/markdown.js"></script>
 <script src="js/impress.js"></script>
 <script>impress().init();</script>
 

--- a/js/markdown.js
+++ b/js/markdown.js
@@ -1,0 +1,26 @@
+(function markdown(){
+  
+  if (!window.marked){
+    var scr = document.createElement('script');
+    scr.src = 'https://raw.github.com/chjj/marked/master/lib/marked.js';
+    scr.onload = markdown;
+    document.body.appendChild(scr);
+    return;
+  }
+
+  [].forEach.call( document.querySelectorAll('.slide'), function  fn(elem){
+      
+    // strip leading whitespace so it isn't evaluated as code
+    var text      = elem.innerHTML.replace(/\n\s*\n/g,'\n'),
+        // set indentation level so your markdown can be indented within your HTML
+        leadingws = text.match(/^\n?(\s*)/)[1].length,
+        regex     = new RegExp('\\n?\\s{' + leadingws + '}','g'),
+        md        = text.replace(regex,'\n'),
+        html      = marked(md);
+
+    // here, have sum HTML
+    elem.innerHTML = html;
+
+  });
+
+}());


### PR DESCRIPTION
- Heavily borrowed from Paul Irish's [gist](https://gist.github.com/1343518)
- Uses [marked lib](https://github.com/chjj/marked)
## Usage
#### Add the script to your presentation

``` html
<script src="js/markdown.js"></script> <!-- add this line -->
<script src="js/impress.js"></script>
<script>impress().init();</script>
```
#### Now you can write slides like this

``` html
<div id="bored" class="step slide" data-x="-1000" data-y="-1500">
      # Aren't you just **bored** with all those slides-based presentations?
</div>
```
