### PR TITLE
Exposed nextStep in the impress:stepleave event for the sake of collaboration

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -288,7 +288,7 @@
         // last entered step.
         var onStepLeave = function (step) {
             if (lastEntered === step) {
-                triggerEvent(step, "impress:stepleave");
+                triggerEvent(step, "impress:stepleave", { nextStep: nextStep.el });
                 lastEntered = null;
             }
         };
@@ -483,7 +483,7 @@
             
             // trigger leave of currently active element (if it's not the same step again)
             if (activeStep && activeStep !== el) {
-                onStepLeave(activeStep);
+                onStepLeave(activeStep, step);
             }
             
             // Now we alter transforms of `root` and `canvas` to trigger transitions.


### PR DESCRIPTION
I wrote a really simple [impress.js presentation sync](https://github.com/TimHeckel/impressr) and in the process modified the impress.js source to surface the nextStep in the impress:stepleave event. I need to know the destination step immediately upon leaving to ensure real-time syncing with minimal lag.

This was a very minor change, I hope you'll consider accepting it into the official release. Thanks for this library! It's wonderfully simple.

Tim