### PR TITLE
innerStep

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,10 @@
     -->
     <div id="bored" class="step slide" data-x="-1000" data-y="-1500">
         <q>Aren't you just <b>bored</b> with all those slides-based presentations?</q>
+        <ul style="margin-top: 50px">
+            <li class="innerStep" style="list-style: circle; margin: 30px 0 0 100px;">That go on and on and on.</li>
+            <li class="innerStep" style="list-style: circle; margin: 30px 0 0 100px;">And do basically the same things.</li>
+        </ul>
     </div>
 
     <!--
@@ -216,9 +220,9 @@
         
     -->
     <div id="its" class="step" data-x="850" data-y="3000" data-rotate="90" data-scale="5">
-        <p>It's a <strong>presentation tool</strong> <br/>
-        inspired by the idea behind <a href="http://prezi.com">prezi.com</a> <br/>
-        and based on the <strong>power of CSS3 transforms and transitions</strong> in modern browsers.</p>
+        <p>It's a <strong>presentation tool</strong></p>
+        <p class="innerStep">inspired by the idea behind <a href="http://prezi.com">prezi.com</a> <br/></p>
+        <p class="innerStep">and based on the <strong>power of CSS3 transforms and transitions</strong> in modern browsers.</p>
     </div>
 
     <div id="big" class="step" data-x="3500" data-y="2100" data-rotate="180" data-scale="6">
@@ -235,7 +239,9 @@
         
     -->
     <div id="tiny" class="step" data-x="2825" data-y="2325" data-z="-3000" data-rotate="300" data-scale="1">
-        <p>and <b>tiny</b> ideas</p>
+        <p> <span class="innerStep shift" style="position:relative;top:-200px;left:-200px;" data-steps='[{"top":"0","left":"0"}]'>and</span>
+            <b class="innerStep shift" data-steps='[{}]'>tiny</b>
+            <span class="innerStep shift" style="position:relative;top:200px;left:200px;" data-steps='[{"top":"0","left":"0"}]'>ideas</span></p>
     </div>
 
     <!--
@@ -288,7 +294,12 @@
         
     -->
     <div id="its-in-3d" class="step" data-x="6200" data-y="4300" data-z="-100" data-rotate-x="-40" data-rotate-y="10" data-scale="2">
-        <p><span class="have">have</span> <span class="you">you</span> <span class="noticed">noticed</span> <span class="its">it's</span> <span class="in">in</span> <b>3D<sup>*</sup></b>?</p>
+        <p> <span class="have innerStep shift" data-steps='[{"position":"relative","color":"#69f"},{"top":"60px","left":"10px","transform":"rotate(300deg)"},{"transform":"rotateY(70deg) rotateX(200deg)"}]'>have</span>
+            <span class="you innerStep shift" data-steps='[{"position":"relative","color":"#69f"},{"top":"20px","left":"110px","transform":"rotate(80deg)"},{"transform":"rotateY(20deg) rotateX(310deg)"}]'>you</span>
+            <span class="noticed innerStep shift" data-steps='[{"position":"relative","color":"#69f"},{"top":"-60px","left":"-200px","transform":"rotate(230deg)"},{"transform":"rotateY(80deg) rotateX(110deg)"}]'>noticed</span>
+            <span class="its innerStep shift" data-steps='[{"position":"relative","color":"#69f"},{"top":"30px","left":"-40px","transform":"rotate(-89deg)"},{"transform":"rotateY(3deg) rotateX(21deg)"}]'>it's</span>
+            <span class="in innerStep shift" data-steps='[{"position":"relative","color":"#69f"},{"top":"200px","left":"-10px","transform":"rotate(170deg)"},{"transform":"rotateY(310deg) rotateX(4deg)"}]'>in</span>
+            <b>3D<sup>*</sup></b>?</p>
         <span class="footnote">* beat that, prezi ;)</span>
     </div>
 


### PR DESCRIPTION
Edited a different way, I was still having problems with hard returns. So this looks much better.
This defaults to a simple innerStep by just showing the step along the way, but also allows for much more robust stepping for effects similar to, but can go way beyond, keynotes magic move.

basically allowing you to apply css styles on a next() call. There are two ways that this could be implemented and I chose this way, using a json object, because I felt it would be cleaner, though it puts some css in the markup.

The second way this could be implemented is to assign a "step" + i class and have the css be in the css file rather than the tag. Seemed like "6's" to me so I chose the json method because that is what I would personally prefer. 

If you want I could do it the class way. 

If you have questions let me know.

Thanks,
Colt