### PR TITLE
Creation of the multistep (substeps) functionnality

### DIFF
--- a/css/impress-demo.css
+++ b/css/impress-demo.css
@@ -378,6 +378,39 @@ a:focus {
 }
 
 /*
+This step introduces substeps.
+At first, it only has one line of text, but after 1 action, it adds one line and changes text color to red, and
+after the second action, adds another line another line and changes the color to green.
+This rule hides the added texts
+*/
+#substeps .substep1,
+#substeps .substep2{
+    display: none;
+}
+
+/*
+Those rules set the style for when the sub steps will be shown
+*/
+#substeps{
+    height:400px;
+    -webkit-transition: color 1s;
+    -moz-transition: color 1s;
+    -ms-transition: color 1s;
+    -o-transition: color 1s;
+    transition: color 1s;
+}
+
+/*
+This rule shows the texts and changes the color when the classes are added
+*/
+.substeps_container_1{color: red;}
+.substeps_container_2{color: green;}
+#substeps.substeps_container_1 .substep1,
+#substeps.substeps_container_2 .substep2{
+    display:block;
+}
+
+/*
     The 'imagination' step is again some boring font-sizing.
 */
 

--- a/index.html
+++ b/index.html
@@ -262,6 +262,31 @@
         <p>by <b class="positioning">positioning</b>, <b class="rotating">rotating</b> and <b class="scaling">scaling</b> them on an infinite canvas</p>
     </div>
 
+    <!--
+        
+        This step introduces substeps.
+	
+        Substeps allow a single step to be called more than once in a row, adding a class
+        everytime, which allows to make parts of the page appear or change when the visitor asks to continue
+        the navigation.
+	
+        It is created using the data-multistep parametter. The value should be a space-separated-list
+        of classes.
+
+        When the step is shown, none of the classes are used. Then, it adds the class "multiStepping"
+        and the first of the classes contained in data-multistep. Then the second is added and the first
+        removed. When the last is reached, both classes (the last one and "multiStepping") are removed
+        and the next step is shown.
+	
+    -->
+    <div id="substeps" data-multistep="substeps_container_1 substeps_container_2" class="step" data-x="4500" data-y="-3000" data-rotate="0" data-scale="6">
+        <p>and by creating <b>substeps</b></p>
+        <ul>
+            <li class="substep1 substep2">that may come</li>
+            <li class="substep2"><b>one by one</b></li>
+        </ul>
+    </div>
+    
     <div id="imagination" class="step" data-x="6700" data-y="-300" data-scale="6">
         <p>the only <b>limit</b> is your <b class="imagination">imagination</b></p>
     </div>

--- a/js/impress.js
+++ b/js/impress.js
@@ -309,8 +309,14 @@
                         z: toNumber(data.rotateZ || data.rotate)
                     },
                     scale: toNumber(data.scale, 1),
+		            multistep: [],
                     el: el
                 };
+
+            // separating the substeps that were given as a string
+            if(data.multistep){
+                step.multistep = data.multistep.split(' ');
+            }
             
             if ( !el.id ) {
                 el.id = "step-" + (idx + 1);
@@ -550,14 +556,61 @@
         
         // `prev` API function goes to previous step (in document order)
         var prev = function () {
+            // Checks if the step contains substeps
+            var multistep = stepsData['impress-'+activeStep.id].multistep;
+            if(multistep != ''){
+                if(activeStep.classList.contains('multiStepping')){
+                    for(var oneStep in multistep){
+                        if(activeStep.classList.contains(multistep[oneStep])){
+                            activeStep.classList.remove(multistep[oneStep]);
+                            if(oneStep != 0){
+                                activeStep.classList.add(multistep[parseInt(oneStep)-1]);
+                            }else{
+                                activeStep.classList.remove('multiStepping');
+                            }
+                            return true;
+                        }
+                    }
+                }
+            }
+            
             var prev = steps.indexOf( activeStep ) - 1;
             prev = prev >= 0 ? steps[ prev ] : steps[ steps.length-1 ];
+            
+            // Prepares the next step to be shown (so the previous one) if it needs so
+            multistep = stepsData['impress-'+prev.id].multistep;
+            if(multistep != ''){
+                prev.classList.add('multiStepping');
+                prev.classList.add(multistep[multistep.length - 1]);
+            }
             
             return goto(prev);
         };
         
         // `next` API function goes to next step (in document order)
         var next = function () {
+            // Checks if the step contains substeps
+            var multistep = stepsData['impress-'+activeStep.id].multistep;
+            if(multistep != ''){
+                if(activeStep.classList.contains('multiStepping')){
+                    for(var oneStep in multistep){
+                        if(activeStep.classList.contains(multistep[oneStep])){
+                            activeStep.classList.remove(multistep[oneStep]);
+                            if(multistep[parseInt(oneStep)+1] != undefined){
+                                activeStep.classList.add(multistep[parseInt(oneStep)+1]);
+                                return true;
+                            }else{
+                                activeStep.classList.remove('multiStepping');
+                            }
+                        }
+                    }
+                }else{
+                    activeStep.classList.add('multiStepping');
+                    activeStep.classList.add(multistep[0]);
+                    return true;
+                }
+            }
+            
             var next = steps.indexOf( activeStep ) + 1;
             next = next < steps.length ? steps[ next ] : steps[ 0 ];
             

--- a/js/impress.js
+++ b/js/impress.js
@@ -272,6 +272,7 @@
         
         // reference to last entered step
         var lastEntered = null;
+        var lastEnteredSub = null;
         
         // `onStepEnter` is called whenever the step element is entered
         // but the event is triggered only if the step is different than
@@ -282,6 +283,17 @@
                 lastEntered = step;
             }
         };
+
+        // `onSubstepEnter` is called whenever the step element is entered
+        // but the event is triggered only if the step is different than
+        // last entered step.
+        var onSubstepEnter = function (step,substep) {
+            activeStep.setAttribute("data-active-substep", substep);
+            triggerEvent(step, "impress:substepenter");
+            if (lastEnteredSub !== substep) {
+                lastEnteredSub = substep;
+            }
+        };
         
         // `onStepLeave` is called whenever the step element is left
         // but the event is triggered only if the step is the same as
@@ -290,6 +302,16 @@
             if (lastEntered === step) {
                 triggerEvent(step, "impress:stepleave");
                 lastEntered = null;
+            }
+        };
+        
+        // `onStepLeave` is called whenever the step element is left
+        // but the event is triggered only if the step is the same as
+        // last entered step.
+        var onSubstepLeave = function (step,substep) {
+            if (lastEnteredSub === substep) {
+                triggerEvent(step, "impress:substepleave");
+                lastEnteredSub = null;
             }
         };
         
@@ -562,9 +584,11 @@
                 if(activeStep.classList.contains('multiStepping')){
                     for(var oneStep in multistep){
                         if(activeStep.classList.contains(multistep[oneStep])){
+                            onSubstepLeave(activeStep,multistep[oneStep]);
                             activeStep.classList.remove(multistep[oneStep]);
                             if(oneStep != 0){
                                 activeStep.classList.add(multistep[parseInt(oneStep)-1]);
+                                onSubstepEnter(activeStep,multistep[parseInt(oneStep)-1]);
                             }else{
                                 activeStep.classList.remove('multiStepping');
                             }
@@ -582,11 +606,12 @@
             if(multistep != ''){
                 prev.classList.add('multiStepping');
                 prev.classList.add(multistep[multistep.length - 1]);
+                onSubstepEnter(activeStep,multistep[multistep.length - 1]);
             }
             
             return goto(prev);
         };
-        
+
         // `next` API function goes to next step (in document order)
         var next = function () {
             // Checks if the step contains substeps
@@ -595,9 +620,11 @@
                 if(activeStep.classList.contains('multiStepping')){
                     for(var oneStep in multistep){
                         if(activeStep.classList.contains(multistep[oneStep])){
+                            onSubstepLeave(activeStep,multistep[oneStep]);
                             activeStep.classList.remove(multistep[oneStep]);
                             if(multistep[parseInt(oneStep)+1] != undefined){
                                 activeStep.classList.add(multistep[parseInt(oneStep)+1]);
+                                onSubstepEnter(activeStep,multistep[parseInt(oneStep)+1]);
                                 return true;
                             }else{
                                 activeStep.classList.remove('multiStepping');
@@ -607,6 +634,7 @@
                 }else{
                     activeStep.classList.add('multiStepping');
                     activeStep.classList.add(multistep[0]);
+                    onSubstepEnter(activeStep,multistep[0]);
                     return true;
                 }
             }


### PR DESCRIPTION
This is the same as https://github.com/bartaz/impress.js/pull/190 , which I closed because the base commit was including irrelevant changes in the indentation.  

Added the substeps / Multistep functionnality that allows to create changes in a single step. Better explained in the example file, between the "positioning-rotating-scaling" step and the "imagination" step. 
It works in both ways (from start to end and from end to start) to enable the users to rewind the presentation.  

As everything in impress.js, it doesn't require javascript skills, only HTML+CSS.  Hope you'll enjoy it!