### PR TITLE
enableHistory default flag

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -84,6 +84,17 @@
     var toNumber = function (numeric, fallback) {
         return isNaN(numeric) ? (fallback || 0) : Number(numeric);
     };
+
+    // `toBool` takes a value given as a bool given as a string parameter and tries to turn
+    // it into a Boolean. If it is not possible it returns false (or other string value
+    // given as `fallback`). Does not convert integer or numeric values.
+
+    // Default JS Boolean constructor behaviour is to convert any non-0 and non-false input to a string. Only returns booleans. Does not raise an error when non-boolean is provided.
+    
+    var toBoolean = function(boolean,fallback){
+      boolFiltered = String(boolean).toLowerCase();
+      return ( boolFiltered === 'false' || boolFiltered) === 'true') ? Boolean(boolFiltered==='true') : (typeof fallback === 'boolean' ? fallback : false);
+    };
     
     // `byId` returns element with given `id` - you probably have guessed that ;)
     var byId = function ( id ) {
@@ -202,7 +213,7 @@
         height: 768,
         maxScale: 1,
         minScale: 0,
-        enableHistory: 1,
+        enableHistory: true,
         
         perspective: 1000,
         
@@ -350,7 +361,8 @@
                 maxScale: toNumber( rootData.maxScale, defaults.maxScale ),
                 minScale: toNumber( rootData.minScale, defaults.minScale ),                
                 perspective: toNumber( rootData.perspective, defaults.perspective ),
-                transitionDuration: toNumber( rootData.transitionDuration, defaults.transitionDuration )
+                transitionDuration: toNumber( rootData.transitionDuration, defaults.transitionDuration ),
+                enableHistory: toBoolean( rootData.enableHistory, defaults.enableHistory ) 
             };
             
             windowScale = computeWindowScale( config );
@@ -611,8 +623,9 @@
             // BUG: http://code.google.com/p/chromium/issues/detail?id=62820
 
             // JamesMeldrum: Added flag to disable history tracking. Integrated it with defaults - didn't want to mess with your options object too much :D
+            //               On feedback from Bartek, integerated config object, restored defaults.
 
-            if(defaults.enableHistory){
+            if(config.enableHistory){
                 root.addEventListener("impress:stepenter", function (event) {
                     window.location.hash = lastHash = "#/" + event.target.id;
                 }, false);


### PR DESCRIPTION
Added flag to disable history tracking. It interferes with some other frameworks (backbone.js, ember.js). It would be nice if this feature was optional :D
