### PR TITLE
Adding support for iPhone and iPod

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -179,7 +179,7 @@
                           // but some mobile devices need to be blacklisted,
                           // because their CSS 3D support or hardware is not
                           // good enough to run impress.js properly, sorry...
-                           ( ua.search(/(iphone)|(ipod)|(android)/) === -1 );
+                           ( ua.search(/(android)/) === -1 );
     
     if (!impressSupported) {
         // we can't be sure that `classList` is supported


### PR DESCRIPTION
Now iPhone and iPod are now capable of supporting the impress.js animations and it works on these devices.