### PR TITLE
The HTML5 dataset API does not allow uppercase letters

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -346,10 +346,10 @@
             config = {
                 width: toNumber( rootData.width, defaults.width ),
                 height: toNumber( rootData.height, defaults.height ),
-                maxScale: toNumber( rootData.maxScale, defaults.maxScale ),
-                minScale: toNumber( rootData.minScale, defaults.minScale ),                
+                maxScale: toNumber( rootData.maxscale, defaults.maxScale ),
+                minScale: toNumber( rootData.minscale, defaults.minScale ),                
                 perspective: toNumber( rootData.perspective, defaults.perspective ),
-                transitionDuration: toNumber( rootData.transitionDuration, defaults.transitionDuration )
+                transitionDuration: toNumber( rootData.transitionduration, defaults.transitionDuration )
             };
             
             windowScale = computeWindowScale( config );


### PR DESCRIPTION
Hi Bartek Szopka!

I love impress.js, it is truely a tidy, compact and powerful library!

When trying to allow the slides to scale to the full window size on large monitors I encountered a problem setting the "maxScale" value through the HTML5 dataset API, I traced it down to uppercase letters when initializing "maxScale".

Cheers,
David
