### PR TITLE
Incorporate / port .skip patch

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -427,6 +427,14 @@
                 return false;
             }
             
+            if ( el.classList.contains("skip") ) {
+                var skippedOffset = steps.indexOf(activeStep) > steps.indexOf(el) ? -1 : 1;
+                var skipped = steps.indexOf(el) + skippedOffset;
+                skipped = skipped < steps.length ? steps[skipped] : steps[0];
+                goto(skipped);
+                return false;
+            }
+            
             // Sometimes it's possible to trigger focus on first link with some keyboard action.
             // Browser in such a case tries to scroll the page to make this element visible
             // (even that body overflow is set to hidden) and it breaks our careful positioning.


### PR DESCRIPTION
Original commit: https://github.com/austinbv/impress.js/commit/f6aaa9f7d9700f362796464a0e3dc88a51bff8eb

Original commit message:

  Skippable positions

  It's nice to be able to remain consistent with the markup for background
  stuff but maybe you don't want it in a slide. Now you can add .skip to an
  element and it will be positioned but not scrolled to. Maybe a little hacky
  but it gets the job done right!