### PR TITLE
added getActiveStep to api

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -227,7 +227,8 @@
                 init: empty,
                 goto: empty,
                 prev: empty,
-                next: empty
+                next: empty,
+                getActiveStep: empty
             };
         }
         
@@ -564,6 +565,11 @@
             return goto(next);
         };
         
+        // `getActiveStep` API function to get active step
+        var getActiveStep = function () {
+            return (activeStep) ? activeStep : document.createElement('div');
+        };
+        
         // Adding some useful classes to step elements.
         //
         // All the steps that have not been shown yet are given `future` class.
@@ -635,7 +641,8 @@
             init: init,
             goto: goto,
             next: next,
-            prev: prev
+            prev: prev,
+            getActiveStep: getActiveStep
         });
 
     };


### PR DESCRIPTION
api.getActiveStep() returns the active element, or an empty div if api.init() has not been called.

I wanted to call a setTimeout on api.next() unless the last slide in my presentation is active:

```javascript
function doNext() {
    api.next();
    if (api.getActiveStep().id !== 'my-last-step') {
        setTimeout(function(){
            doNext();
        }, 2000);
    }
}
```

This would also allow you to do things with custom data attributes:
```
<div id="impress">
    <div class="step" data-time-to-next-transition="5000">hello</div>
</div>
<script>
var timeToNextTransition = api.getActiveStep().dataset.timeToNextTransition;
setTimeout(function(){
    api.next();
}, timeToNextTransition);
</script>
```