### PR TITLE
Added ability to pass steps' data as object parameter

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -301,7 +301,7 @@
         // data attributes and setting correct styles.
         var initStep = function ( el, idx ) {
             var data = el.dataset,
-                option = options[el.id],
+                option = options['steps'][el.id],
                 step = {
                     translate: {
                         x: toNumber(data.x, (option)? option.x : 0),


### PR DESCRIPTION
Alternative data assignment to HTML data attributes. Easier (for me) instead do it in the middle of HTML jungle. Also add possibility to provide data from external JS operations. Allowing usage like this

``` javascript
// rotate = r
// 'slide1' and 'slide2' are step's id

impress.init({
    slide1: { x: -125, y: 50, z: -125, r: 90, scale: 0.5 },
    slide2: { x: 105, y: 50, z: -125, rx: 45, ry: -90, rz: 45, scale: 0.5 }
});
```

If anything wrong please let me know.
