### PR TITLE
Added (corrected) steps data as options

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -293,22 +293,27 @@
             }
         };
         
+        // `options` is global variable that hold user-passed object,
+        // containing data for each `step` el
+        var options = {};
+        
         // `initStep` initializes given step element by reading data from its
         // data attributes and setting correct styles.
         var initStep = function ( el, idx ) {
             var data = el.dataset,
+                option = options['steps'][el.id],
                 step = {
                     translate: {
-                        x: toNumber(data.x),
-                        y: toNumber(data.y),
-                        z: toNumber(data.z)
+                        x: toNumber(data.x, (option)? option.x : 0),
+                        y: toNumber(data.y, (option)? option.y : 0),
+                        z: toNumber(data.z, (option)? option.z : 0)
                     },
                     rotate: {
-                        x: toNumber(data.rotateX),
-                        y: toNumber(data.rotateY),
-                        z: toNumber(data.rotateZ || data.rotate)
+                        x: toNumber(data.rotateX, (option)? option.rotateX : 0),
+                        y: toNumber(data.rotateY, (option)? option.rotateY : 0),
+                        z: toNumber(data.rotateZ || data.rotate, (option)? option.rotateZ || option.rotate : 0)
                     },
-                    scale: toNumber(data.scale, 1),
+                    scale: toNumber(data.scale, (option)? option.scale : 1),
                     el: el
                 };
             
@@ -329,8 +334,11 @@
         };
         
         // `init` API function that initializes (and runs) the presentation.
-        var init = function () {
+        // Added optional options object as parameter.
+        var init = function (argOptions) {
             if (initialized) { return; }
+            
+            options = argOptions || options;
             
             // First we set up the viewport for mobile devices.
             // For some reason iPad goes nuts when it is not done properly.


### PR DESCRIPTION
Corrected pull request from #297 since no option to change branch comparison.

> Alternative data assignment to HTML data attributes. Easier (for me) instead do it in the middle of HTML jungle. Also add possibility to provide data from external JS operations. Allowing usage like this

```javascript
// 'slide1' and 'slide2' are step's id

impress.init({
	steps: {
		slide1: { x: -125, y: 50, z: -125, rotate: 90, scale: 0.5 },
		slide2: { x: 105, y: 50, z: -125, rotateX: 45, rotateY: -90, rotateZ: 45 }
	}
});
```
If anything wrong please let me know.