### PR TITLE
meta keys affecting tab

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -703,6 +703,11 @@
         //   consistency I should add [shift+tab] as opposite action...
         document.addEventListener("keyup", function ( event ) {
             if ( event.keyCode === 9 || ( event.keyCode >= 32 && event.keyCode <= 34 ) || (event.keyCode >= 37 && event.keyCode <= 40) ) {
+                if ( event.metaKey || event.altKey || event.ctrlKey ) {
+                    return;
+                }
+
+
                 switch( event.keyCode ) {
                     case 33: // pg up
                     case 37: // left


### PR DESCRIPTION
dont let meta keys advance the presentation as they are used to change windows most often. Although ctrl + left and ctrl + right are used to go forward and back in history. this may need further testing and feedback
