### PR TITLE
init() reset method

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -217,7 +217,7 @@
     // It's the core `impress` function that returns the impress.js API
     // for a presentation based on the element with given id ('impress'
     // by default).
-    var impress = window.impress = function ( rootId ) {
+	var impress = window.impress = function ( rootId, reset ) {
         
         // If impress.js is not supported by the browser return a dummy API
         // it may not be a perfect solution but we return early and avoid
@@ -231,6 +231,9 @@
             };
         }
         
+		if (reset) {
+			roots = {};
+		}
         rootId = rootId || "impress";
         
         // if given root is already initialized just return the API


### PR DESCRIPTION
Initially forked the impress.js repo to create dependency for our
project. We could not init() consecutively without trouble; impress
would not setup the presentation correctly on the second init(). Likely
because roots is not flushed on init() and so remains the second time
with stale data. This change seems to fix it.