### PR TITLE
Impress.js script now runs when page load is complete

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -21,6 +21,10 @@
 
 // You are one of those who like to know how things work inside?
 // Let me show you the cogs that make impress.js run...
+
+// Al this script loads only when the complete page is loaded, so you can load the Impress.js <script> tag
+// from the <head> without problems and avoid loading it from the end of the <body> tag
+window.onload = function(){
 (function ( document, window ) {
     'use strict';
     
@@ -790,6 +794,8 @@
     }, false);
         
 })(document, window);
+
+};
 
 // THAT'S ALL FOLKS!
 //


### PR DESCRIPTION
Added a window.onload event for all the impress.js script, 
so now you can load the impress.js script tag from head. There's no need to load it from the end of the body tag.