### PR TITLE
Add support for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "impress.js",
+  "version": "0.5.3",
+  "description": "It's a presentation framework based on the power of CSS3 transforms and transitions in modern browsers and inspired by the idea behind prezi.com.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bartaz/impress.js.git"
+  },
+  "keywords": [
+    "presentation",
+    "css3",
+    "transitions",
+    "transforms",
+    "beautiful"
+  ],
+  "author": "Bartek Szopka",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bartaz/impress.js/issues"
+  },
+  "homepage": "https://github.com/bartaz/impress.js"
+}


### PR DESCRIPTION
[npm](https://npmjs.org) is the package manager for JavaScript and it would be awesome if impress.js could be installed with it. This pull request adds the `package.json` file which is the basis for publishing it to npm.

If you're ok with it and this gets merged, you can easily publish this by just running `npm publish`.