### PR TITLE
Shift+Tab now goes back to previous step. Issue #446 fixed.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -23,7 +23,7 @@
 // Let me show you the cogs that make impress.js run...
 (function ( document, window ) {
     'use strict';
-    
+    	
     // HELPER FUNCTIONS
     
     // `pfx` is a function that takes a standard CSS property name as a parameter
@@ -699,8 +699,8 @@
         //   Well, the [tab] key by default navigates around focusable elements, so clicking
         //   it very often caused scrolling to focused element and breaking impress.js
         //   positioning. I didn't want to just prevent this default action, so I used [tab]
-        //   as another way to moving to next step... And yes, I know that for the sake of
-        //   consistency I should add [shift+tab] as opposite action...
+        //   as another way to moving to next step... For the sake of consistency [shift+tab]
+        //   works as the opposite action.
         document.addEventListener("keyup", function ( event ) {
             if ( event.keyCode === 9 || ( event.keyCode >= 32 && event.keyCode <= 34 ) || (event.keyCode >= 37 && event.keyCode <= 40) ) {
                 switch( event.keyCode ) {
@@ -709,15 +709,20 @@
                     case 38: // up
                              api.prev();
                              break;
-                    case 9:  // tab
                     case 32: // space
                     case 34: // pg down
                     case 39: // right
                     case 40: // down
                              api.next();
                              break;
+					case 9:  // tab
+							 if (event.shiftKey) {
+								api.prev();
+							 } else {
+								api.next();
+							 }
+							 break;
                 }
-                
                 event.preventDefault();
             }
         }, false);


### PR DESCRIPTION
See comments in new issue #446.