### PR TITLE
Feature: Substeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+This is a fork of impress.js. It supports substeps, but besides that, its the same as the original. The link of the original is: https://github.com/bartaz/impress.js.
+
 impress.js
 ============
-
 It's a presentation framework based on the power of CSS3 transforms and 
 transitions in modern browsers and inspired by the idea behind prezi.com.
 
@@ -12,7 +13,7 @@ impress.js may not help you if you have nothing interesting to say ;)
 HOW TO USE IT
 ---------------
 
-[Use the source](http://github.com/bartaz/impress.js/blob/master/index.html), Luke ;)
+[Use the source](https://github.com/patricebeutler/impress.js/blob/master/index.html), Luke ;)
 
 If you have no idea what I mean by that, or you just clicked that link above and got 
 very confused by all these strange characters that got displayed on your screen,
@@ -30,7 +31,7 @@ EXAMPLES AND OTHER LEARNING RESOURCES
 
 ### Official demo
 
-[impress.js demo](http://bartaz.github.com/impress.js) by [@bartaz](http://twitter.com/bartaz)
+Look at the html-file in this repo. It is slightli different than the original from bartaz.
 
 ### Examples and demos
 
@@ -46,17 +47,6 @@ on the wiki, too.
 There is also a book available about [Building impressive presentations with impress.js](http://www.packtpub.com/building-impressive-presentations-with-impressjs/book) by Rakhitha Nimesh Ratnayake.
 
 
-WANT TO CONTRIBUTE?
----------------------
-
-If you've found a bug or have a great idea for new feature let me know by [adding your suggestion]
-(http://github.com/bartaz/impress.js/issues/new) to [issues list](https://github.com/bartaz/impress.js/issues).
-
-If you have fixed a bug or implemented a feature that you'd like to share, send your pull request against [dev branch]
-(http://github.com/bartaz/impress.js/tree/dev). But remember that I only accept code that fits my vision of impress.js
-and my coding standards - so make sure you are open for discussion :)
-
-
 
 ABOUT THE NAME
 ----------------
@@ -64,164 +54,6 @@ ABOUT THE NAME
 impress.js name in [courtesy of @skuzniak](http://twitter.com/skuzniak/status/143627215165333504).
 
 It's an (un)fortunate coincidence that a Open/LibreOffice presentation tool is called Impress ;)
-
-
-
-VERSION HISTORY
------------------
-
-### 0.5.3 ([browse](http://github.com/bartaz/impress.js/tree/0.5.3), [zip](http://github.com/bartaz/impress.js/zipball/0.5.3), [tar](http://github.com/bartaz/impress.js/tarball/0.5.3))
-
-#### BUGFIX RELEASE
-
-Version 0.5 introduced events including `impress:stepenter`, but this event was not triggered properly in some
-specific transition types (for example when only scale was changing between steps). It was caused by the fact that
-in such cases expected `transitionend` event was not triggered.
-
-This version fixes this issue. Unfortunately modern `transitionend` event is no longer used to detect when the
-transition has finished, but old school (and more reliable) `setTimeout` is used.
-
-
-### 0.5.2 ([browse](http://github.com/bartaz/impress.js/tree/0.5.2), [zip](http://github.com/bartaz/impress.js/zipball/0.5.2), [tar](http://github.com/bartaz/impress.js/tarball/0.5.2))
-
-#### DOCUMENTATION RELEASE
-
-More descriptive comments added to demo CSS and impress.js source file, so now not only `index.html` is worth reading ;)
-
-
-### 0.5.1 ([browse](http://github.com/bartaz/impress.js/tree/0.5.1), [zip](http://github.com/bartaz/impress.js/zipball/0.5.1), [tar](http://github.com/bartaz/impress.js/tarball/0.5.1))
-
-#### BUGFIX RELEASE
-
-Changes in version 0.5 introduced a bug (#126) that was preventing clicks on links (or any clickable elements) on
-currently active step. This release fixes this issue.
-
-
-
-### 0.5 ([browse](http://github.com/bartaz/impress.js/tree/0.5), [zip](http://github.com/bartaz/impress.js/zipball/0.5), [tar](http://github.com/bartaz/impress.js/tarball/0.5))
-
-#### CHANGELOG
-
-* API changed, so that `impress()` function no longer automatically initialize presentation; new method called `init`
-  was added to API and it should be used to start the presentation
-* event `impress:init` is triggered on root presentation element (`#impress` by default) when presentation is initialized
-* new CSS classes were added: `impress-disabled` is added to body element by the impress.js script and it's changed to 
-  `impress-enabled` when `init()` function is called
-* events added when step is entered and left - custom `impress:stepenter` and `impress:stepleave` events are triggered
-  on step elements and can be handled like any other DOM events (with `addEventListener`)
-* additional `past`, `present` and `future` classes are added to step elements
-    - `future` class appears on steps that were not yet visited
-    - `present` class appears on currently visible step - it's different from `active` class as `present` class
-       is added when transition finishes (step is entered)
-    - `past` class is added to already visited steps (when the step is left)
-* and good news, `goto()` API method is back! it seems that `goto` **was** a future reserved word but isn't anymore,
-  so we can use this short and pretty name instead of camelCassy `stepTo` - and yes, that means API changed again...
-* additionally `goto()` method now supports new types of parameters:
-    - you can give it a number of step you want to go to: `impress().goto(7)`
-    - or its id: `impress().goto("the-best-slide-ever")`
-    - of course DOM element is still acceptable: `impress().goto( document.getElementById("overview") )`
-* and if it's not enough, `goto()` also accepts second parameter to define the transition duration in ms, for example
-  `impress().goto("make-it-quick", 300)` or `impress().goto("now", 0)`
-
-#### UPGRADING FROM PREVIOUS VERSIONS
-
-In current version calling `impress()` doesn't automatically initialize the presentation. You need to call `init()`
-function from the API. So in a place were you called `impress()` to initialize impress.js simply change this call
-to `impress().init()`.
-
-Version 0.4 changed `goto` API method into `stepTo`. It turned out that `goto` is not a reserved word anymore, so it
-can be used in JavaScript. That's why version 0.5 brings it back and removes `stepTo`.
-
-So if you have been using version 0.4 and have any reference to `stepTo` API method make sure to change it to `goto`.
-
-
-
-### 0.4.1 ([browse](http://github.com/bartaz/impress.js/tree/0.4.1), [zip](http://github.com/bartaz/impress.js/zipball/0.4.1), [tar](http://github.com/bartaz/impress.js/tarball/0.4.1))
-
-#### BUGFIX RELEASE
-
-Changes is version 0.4 introduced a bug causing JavaScript errors being thrown all over the place in fallback mode.
-This release fixes this issue.
-
-It also adds a flag `impress.supported` that can be used in JavaScript to check if impress.js is supported in the browser.
-
-
-
-### 0.4 ([browse](http://github.com/bartaz/impress.js/tree/0.4), [zip](http://github.com/bartaz/impress.js/zipball/0.4), [tar](http://github.com/bartaz/impress.js/tarball/0.4))
-
-#### CHANGELOG
-
-* configuration options on `#impress` element: `data-perspective` (in px, defaults so 1000),
-  `data-transition-duration` (in ms, defaults to 1000)
-* automatic scaling to fit window size, with configuration options:  `data-width` (in px, defaults to 1024),
-  `data-height` (in px, defaults to 768), `max-scale` (defaults to 1), `min-scale` (defaults to 0)
-* `goto` API function was renamed to `stepTo` because `goto` is a future reserved work in JavaScript,
-  so **please make sure to update your code**
-* fallback `impress-not-supported` class is now set on `body` element instead of `#impress` element and it's
-  replaced with `impress-supported` when browser supports all required features
-* classes `step-ID` used to indicate progress of the presentation are now renamed to `impress-on-ID` and are
-  set on `body` element, so **please make sure to update your code**
-* basic validation of configuration options
-* couple of typos and bugs fixed
-* favicon added ;)
-
-
-#### UPGRADING FROM PREVIOUS VERSIONS
-
-If in your custom JavaScript code you were using `goto()` function from impress.js API make sure to change it
-to `stepTo()`.
-
-If in your CSS you were using classes based on currently active step with `step-` prefix, such as `step-bored`
-(where `bored` is the id of the step element) make sure to change it to `impress-on-` prefix
-(for example `impress-on-bored`). Also in previous versions these classes were assigned to `#impress` element
-and now they are added to `body` element, so if your CSS code depends on this, it also should be updated.
-
-Same happened to `impress-not-supported` class name - it was moved from `#impress` element to `body`, so update
-your CSS if it's needed.
-
-#### NOTE ON BLACKBERRY PLAYBOOK
-
-Changes and fixes added in this version have broken the experience on Blackberry Playbook with OS in version 1.0.
-It happened due to a bug in the Playbook browser in this version. Fortunately in version 2.0 of Playbook OS this
-bug was fixed and impress.js works fine.
-
-So currently impress.js work only on Blackberry Playbook with latest OS. Fortunately, [it seems that most of the
-users](http://twitter.com/n_adam_stanley/status/178188611827679233) [are quite quick with updating their devices]
-(http://twitter.com/brcewane/status/178230406196379648)
-
-
-
-### 0.3 ([browse](http://github.com/bartaz/impress.js/tree/0.3), [zip](http://github.com/bartaz/impress.js/zipball/0.3), [tar](http://github.com/bartaz/impress.js/tarball/0.3))
-
-#### CHANGELOG
-
-* minor CSS 3D fixes
-* basic API to control the presentation flow from JavaScript
-* touch event support
-* basic support for iPad (iOS 5 and iOS 4 with polyfills) and Blackberry Playbook
-
-#### UPGRADING FROM PREVIOUS VERSIONS
-
-Because API was introduced the way impress.js script is initialized was changed a bit. You not only has to include
-`impress.js` script file, but also call `impress()` function.
-
-See the source of `index.html` for example and more details.
-
-
-### 0.2 ([browse](http://github.com/bartaz/impress.js/tree/0.2), [zip](http://github.com/bartaz/impress.js/zipball/0.2), [tar](http://github.com/bartaz/impress.js/tarball/0.2))
-
-* tutorial/documentation added to `index.html` source file
-* being even more strict with strict mode
-* code clean-up
-* couple of small bug-fixes
-
-
-### 0.1 ([browse](http://github.com/bartaz/impress.js/tree/0.1), [zip](http://github.com/bartaz/impress.js/zipball/0.1), [tar](http://github.com/bartaz/impress.js/tarball/0.1))
-
-First release.
-
-Contains basic functionality for step placement and transitions between them
-with simple fallback for non-supporting browsers.
 
 
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/bartaz/impress.js",
   "license" : ["http://bartaz.mit-license.org/", "http://www.gnu.org/licenses/"],
   "main": [
-    "./js/impress.js",
+    "./js/impress.js"
   ],
   "keywords": [
     "slideshow",

--- a/css/impress-demo.css
+++ b/css/impress-demo.css
@@ -382,11 +382,29 @@ a:focus {
 */
 
 #imagination {
-    width: 600px;
+    width: 640px;
 }
 
 #imagination .imagination {
     font-size: 78px;
+}
+
+/*
+    The 'substeps' step has some substeps. These substeps are hidden at first and then shown later.
+    1. If the height is not specified, the vertical-center of the step will change when the height changes dynamically.
+       When using substeps that are showing content that alter the height, make sure to specify the height.
+*/
+#substeps {
+    width: 640px;
+    height: 230px; /* 1 */
+}
+
+#substeps .areThere, #substeps .ofCourse {
+    display: none;
+}
+
+#substeps .areThereVisible, #substeps .ofCourceVisible {
+    display: inline-block;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -388,11 +388,6 @@ if ("ontouchstart" in document.documentElement) {
                                                              duration of the transition in ms, but it's optional - if not 
                                                              provided default transition duration for the presentation 
                                                              will be used.
-            
-            `api.addEnterActionToStep( stepId, function )` - Adds a function to the step with the specified stepId (data-stepId). 
-                                                             This function is executed when a step is entered.
-                                                             stepId:   The stepid provided in the data-stepid-attribute.
-                                                             function: The function that should be executed.
                                                              
             `api.addActionToStep( stepId, function )`      - Adds a function to the step with the specified stepId (data-stepId). 
                                                              This function adds a substep to a step. There can be 
@@ -404,11 +399,6 @@ if ("ontouchstart" in document.documentElement) {
                                                              This function is executed when the 'prev'-command is
                                                              executed on a step has already executed at least one
                                                              action (added by addActionToStep (above)). 
-                                                             stepId:   The stepid provided in the data-stepid-attribute.
-                                                             function: The function that should be executed.
-                                                             
-            `api.addLeftActionToStep( stepId, function )`  - Adds a function to the step with the specified stepId (data-stepId).
-                                                             This function is executed when a step is left.
                                                              stepId:   The stepid provided in the data-stepid-attribute.
                                                              function: The function that should be executed.
         

--- a/index.html
+++ b/index.html
@@ -262,10 +262,16 @@
         <p>by <b class="positioning">positioning</b>, <b class="rotating">rotating</b> and <b class="scaling">scaling</b> them on an infinite canvas</p>
     </div>
 
-    <div id="imagination" class="step" data-x="6700" data-y="-300" data-scale="6">
+    
+    <div id="imagination" class="step" data-x="6700" data-y="-1400" data-scale="6">
         <p>the only <b>limit</b> is your <b class="imagination">imagination</b></p>
     </div>
 
+    <div id="substeps" class="step" data-x="6700" data-y="-100" data-scale="6" data-stepId="substeps">
+        <p>Are there <b>substeps</b> too?</p> 
+        <p><span class="areThere">Are there?</span> <span class="ofCourse">Of course!</span></p>
+    </div>
+    
     <div id="source" class="step" data-x="6300" data-y="2000" data-rotate="20" data-scale="4">
         <p>want to know more?</p>
         <q><a href="http://github.com/bartaz/impress.js">use the source</a>, Luke!</q>
@@ -361,32 +367,73 @@ if ("ontouchstart" in document.documentElement) {
     
 -->
 <script src="js/impress.js"></script>
-<script>impress().init();</script>
+<script>
+    /*
+        The `impress()` function also gives you access to the API that controls the presentation.
+        
+        Just store the result of the call:
+        
+            var api = impress();
+        
+        and you will get nine functions you can call:
+        
+            `api.init()` - initializes the presentation,
+            
+            `api.next()` - moves to next step of the presentation,
+            
+            `api.prev()` - moves to previous step of the presentation,
+            
+            `api.goto( idx | id | element, [duration] )`   - moves the presentation to the step given by its index number
+                                                             id or the DOM element; second parameter can be used to define 
+                                                             duration of the transition in ms, but it's optional - if not 
+                                                             provided default transition duration for the presentation 
+                                                             will be used.
+            
+            `api.addEnterActionToStep( stepId, function )` - Adds a function to the step with the specified stepId (data-stepId). 
+                                                             This function is executed when a step is entered.
+                                                             stepId:   The stepid provided in the data-stepid-attribute.
+                                                             function: The function that should be executed.
+                                                             
+            `api.addActionToStep( stepId, function )`      - Adds a function to the step with the specified stepId (data-stepId). 
+                                                             This function adds a substep to a step. There can be 
+                                                             more than one actions per step.
+                                                             stepId:   The stepid provided in the data-stepid-attribute.
+                                                             function: The function that should be executed.
+                                                             
+            `api.addResetActionToStep( stepId, function )` - Adds a function to the step with the specified stepId (data-stepId).
+                                                             This function is executed when the 'prev'-command is
+                                                             executed on a step has already executed at least one
+                                                             action (added by addActionToStep (above)). 
+                                                             stepId:   The stepid provided in the data-stepid-attribute.
+                                                             function: The function that should be executed.
+                                                             
+            `api.addLeftActionToStep( stepId, function )`  - Adds a function to the step with the specified stepId (data-stepId).
+                                                             This function is executed when a step is left.
+                                                             stepId:   The stepid provided in the data-stepid-attribute.
+                                                             function: The function that should be executed.
+        
+        You can also simply call `impress()` again to get the API, so `impress().next()` is also allowed.
+        Don't worry, it wont initialize the presentation again.
+        
+        For some example uses of this API check the last part of the source of impress.js where the API
+        is used in event handlers.
+    */
 
-<!--
-    
-    The `impress()` function also gives you access to the API that controls the presentation.
-    
-    Just store the result of the call:
-    
+    // Subscribe to the `impress:init`-event to add the actions to the steps after impress is initialized.
+    document.getElementById("impress").addEventListener("impress:init", function(){ 
         var api = impress();
-    
-    and you will get three functions you can call:
-    
-        `api.init()` - initializes the presentation,
-        `api.next()` - moves to next step of the presentation,
-        `api.prev()` - moves to previous step of the presentation,
-        `api.goto( idx | id | element, [duration] )` - moves the presentation to the step given by its index number
-                id or the DOM element; second parameter can be used to define duration of the transition in ms,
-                but it's optional - if not provided default transition duration for the presentation will be used.
-    
-    You can also simply call `impress()` again to get the API, so `impress().next()` is also allowed.
-    Don't worry, it wont initialize the presentation again.
-    
-    For some example uses of this API check the last part of the source of impress.js where the API
-    is used in event handlers.
-    
--->
+         
+        api.addActionToStep('substeps', function(stepElement){ stepElement.querySelector(".areThere").classList.add("areThereVisible"); });
+        api.addActionToStep('substeps', function(stepElement){ stepElement.querySelector(".ofCourse").classList.add("ofCourceVisible"); });
+        
+        api.addResetActionToStep('substeps', function(stepElement){ 
+            stepElement.querySelector(".areThere").classList.remove("areThereVisible");
+            stepElement.querySelector(".ofCourse").classList.remove("ofCourceVisible");
+        });
+    });
+
+    impress().init();
+</script>
 
 </body>
 </html>
@@ -435,4 +482,3 @@ if ("ontouchstart" in document.documentElement) {
     Cheers!
     
 -->
-

--- a/index.html
+++ b/index.html
@@ -52,8 +52,12 @@
     And that's how impress.js presentations are built-- with HTML and CSS code.
     
     Believe me, you need quite decent HTML and CSS skills to be able to use impress.js effectively.
+<<<<<<< HEAD
+    More importantly, you need to be a designer. There are no default styles or layouts for impress.js presentations.
+=======
     And what is even more important is that you need to be a designer too, because there are no default
     styles for impress.js presentations and there is no default or automatic layout for them.
+>>>>>>> origin/dev
     
     You need to design and build it by hand.
     
@@ -77,7 +81,7 @@
 
     <!--
         
-        Impress.js doesn't depend on any external stylesheet. Script adds all styles it needs for
+        Impress.js doesn't depend on any external stylesheets. It adds all of the styles it needs for the
         presentation to work.
         
         This style below contains styles only for demo presentation. Browse it to see how impress.js
@@ -141,7 +145,7 @@
     If you are willing to change this value make sure you understand how CSS perspective works:
     https://developer.mozilla.org/en/CSS/perspective
     
-    But as I said, you won't need it for now, so don't worry - there are some simple but interesing things
+    But as I said, you won't need it for now, so don't worry - there are some simple but interesting things
     right around the corner of this tag ;)
     
 -->
@@ -300,7 +304,7 @@
 
     <!--
         
-        So to make a summary of all the possible attributes used to position presentation steps, we have:
+        So to summarize of all the possible attributes used to position presentation steps, we have:
         
         * `data-x`, `data-y`, `data-z` - they define the position of **the center** of step element on
             the canvas in pixels; their default value is 0;

--- a/js/impress.js
+++ b/js/impress.js
@@ -19,7 +19,7 @@
 /*jshint bitwise:true, curly:true, eqeqeq:true, forin:true, latedef:true, newcap:true,
          noarg:true, noempty:true, undef:true, strict:true, browser:true */
 
-// You are one of those who like to know how thing work inside?
+// You are one of those who like to know how things work inside?
 // Let me show you the cogs that make impress.js run...
 (function ( document, window ) {
     'use strict';
@@ -191,7 +191,7 @@
     
     // GLOBALS AND DEFAULTS
     
-    // This is were the root elements of all impress.js instances will be kept.
+    // This is where the root elements of all impress.js instances will be kept.
     // Yes, this means you can have more than one instance on a page, but I'm not
     // sure if it makes any sense in practice ;)
     var roots = {};

--- a/js/impress.js
+++ b/js/impress.js
@@ -229,9 +229,7 @@
                 prev: empty,
                 next: empty,
                 addActionToStep: empty,
-                addResetActionToStep: empty,
-                addEnterActionToStep: empty,
-                addLeftActionToStep: empty
+                addResetActionToStep: empty
             };
         }
         
@@ -316,9 +314,7 @@
                     el: el,
                     actions: [],
                     activeAction: 0,
-                    resetAction: null,
-                    enterAction: null,
-                    leftAction: null
+                    resetAction: null
                 };
             
             if ( !el.id ) {
@@ -552,9 +548,6 @@
             window.clearTimeout(stepEnterTimeout);
             stepEnterTimeout = window.setTimeout(function() {
                 onStepEnter(activeStep);
-                   
-                var activeStepsData = stepsData['impress-' + activeStep.id];
-                if (activeStepsData.enterAction !== null) activeStepsData.enterAction(activeStepsData.el);
             }, duration + delay);
             
             return el;
@@ -573,8 +566,6 @@
             else {
                 var prev = steps.indexOf( activeStep ) - 1;
                 prev = prev >= 0 ? steps[ prev ] : steps[ steps.length-1 ];
-                
-                if (activeStepsData.leftAction !== null) activeStepsData.leftAction(activeStepsData.el);
                 
                 return goto(prev);
             }
@@ -595,15 +586,8 @@
                 var next = steps.indexOf( activeStep ) + 1;
                 next = next < steps.length ? steps[ next ] : steps[ 0 ];
                 
-                if (activeStepsData.leftAction !== null) activeStepsData.leftAction(activeStepsData.el);
-                
                 return goto(next);
             }
-        };
-
-        // `addEnterActionToStep` API function adds a function to a step which is called when the step is entered      
-        var addEnterActionToStep = function(id, enterAction){
-            stepsData['impress-' + id].enterAction = enterAction;
         };
   
         // `addActionToStep` API function adds a function to a step which is called when next is called.
@@ -616,11 +600,6 @@
         // there already are actions executed on that step
         var addResetActionToStep = function (id, resetAction){
             stepsData['impress-' + id].resetAction = resetAction;
-        };
-        
-        // `addLeftActionToStep` API function adds a function to a step which is called when the step is left
-        var addLeftActionToStep = function(id, leftAction){
-            stepsData['impress-' + id].leftAction = leftAction;
         };
         
         // Adding some useful classes to step elements.
@@ -696,9 +675,7 @@
             next: next,
             prev: prev,
             addActionToStep: addActionToStep,
-            addResetActionToStep: addResetActionToStep,
-            addEnterActionToStep: addEnterActionToStep,
-            addLeftActionToStep: addLeftActionToStep
+            addResetActionToStep: addResetActionToStep
         });
 
     };


### PR DESCRIPTION
We needed the "substep"-feature mentioned in the
https://github.com/bartaz/impress.js/issues/81 issue.

We implemented 4 API functions for assigning functions to the steps.
Every mentioned API function takes two parameters: The id of the step
and a function that should be executed on a given time.

There can be one function per step for entering.
There can be one function per step for leaving.
There can be many functions per step that act as "substeps". The user
can then modify everything he wants with simple js. These functions are
called trough next(). The first defined function is executed first.
There can be one function per step that allows resetting the changes
done by the "substep-functions".

Our changes are all backwards-compatible, so it will not break anything
from anyone. We have tested it with a variety of browsers.

We did this with 13 line html (demo), 10 line css (demo) and 46 lines js
(framework). In total less than 70 lines of code added.

If you have something you want to speak about or you are not happy with,
feel free to discuss.