### PR TITLE
Added better swiping support for touch devices.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -188,12 +188,7 @@
                            
                           // and `classList` and `dataset` APIs
                            ( body.classList ) &&
-                           ( body.dataset ) &&
-                           
-                          // but some mobile devices need to be blacklisted,
-                          // because their CSS 3D support or hardware is not
-                          // good enough to run impress.js properly, sorry...
-                           ( ua.search(/(iphone)|(ipod)/) === -1 );
+                           ( body.dataset );
     
     if (!impressSupported) {
         // we can't be sure that `classList` is supported

--- a/js/impress.js
+++ b/js/impress.js
@@ -656,10 +656,10 @@
         document.addEventListener('touchend', function (event) {
             var totalDiff = lastX - startX;
 
-            if (Math.abs(totalDiff) > window.innerWidth / 2) {
-                if (totalDiff > window.innerWidth / 2) {
+            if (Math.abs(totalDiff) > window.innerWidth / 5 && (totalDiff * lastDX) <= 0) {
+                if (totalDiff > window.innerWidth / 5 && lastDX <= 0) {
                     prev();
-                } else if (totalDiff < -window.innerWidth / 2) {
+                } else if (totalDiff < -window.innerWidth / 5 && lastDX >= 0) {
                     next();
                 }
             } else if (Math.abs(lastDX) > threshold) {

--- a/js/impress.js
+++ b/js/impress.js
@@ -179,7 +179,7 @@
                           // but some mobile devices need to be blacklisted,
                           // because their CSS 3D support or hardware is not
                           // good enough to run impress.js properly, sorry...
-                           ( ua.search(/(iphone)|(ipod)|(android)/) === -1 );
+                           ( ua.search(/(iphone)|(ipod)/) === -1 );
     
     if (!impressSupported) {
         // we can't be sure that `classList` is supported
@@ -761,25 +761,38 @@
             }
         }, false);
         
-        // touch handler to detect taps on the left and right side of the screen
-        // based on awesome work of @hakimel: https://github.com/hakimel/reveal.js
-        document.addEventListener("touchstart", function ( event ) {
-            if (event.touches.length === 1) {
-                var x = event.touches[0].clientX,
-                    width = window.innerWidth * 0.3,
-                    result = null;
-                    
-                if ( x < width ) {
-                    result = api.prev();
-                } else if ( x > window.innerWidth - width ) {
-                    result = api.next();
-                }
-                
-                if (result) {
-                    event.preventDefault();
-                }
+        // Touch handler to detect swiping left and right based on window size.
+        // If the difference in X change is bigger than 1/20 of the screen width,
+        // we simply call an appropriate API function.
+        var lastX = 0;
+        var lastDiff = 0;
+        var threshold = window.innerWidth / 20;
+        var touchCount = 0; // To prevent multi-touch 'jumps' that mess everything up
+
+        document.addEventListener('touchstart', function (event) {
+            console.log(event);
+            if (! touchCount++) {
+                // If touchCount is zero
+                lastX = event.touches[0].clientX;
             }
-        }, false);
+        });
+        document.addEventListener('touchmove', function(event) {
+            var x = event.touches[0].clientX;
+            lastDiff = lastX - x;
+            lastX = x;
+        });
+        document.addEventListener('touchend', function (event) {
+            if (lastDiff < -threshold) {
+                api.prev();
+            } else if (lastDiff > threshold) {
+                api.next();
+            }
+
+            lastX = 0;
+            lastDiff = 0;
+
+            touchCount--;
+        });
         
         // rescale presentation when window is resized
         window.addEventListener("resize", throttle(function () {


### PR DESCRIPTION
So, recently I've been doing some stuff for a presentation and noticed that it is not working on my Android.

A little examination has shown me that Android, iPhone and iPad are blacklisted for the swipe.

I think the time has come to disable the blacklist as most modern (and not-so-modern) devices nowadays work flawlessly with Impress.JS.

So, I've implemented a "swipe" left & right effect and removed "Android" User-Agent from the blacklist.

Check out the video below.

[![Impress.JS swipe demo](https://i.ytimg.com/vi/9MgFKaHCONY/3.jpg)](https://www.youtube.com/watch?v=9MgFKaHCONY&feature=youtu.be)

Hope this is useful to somebody :)
