### PR TITLE
fix for issue #238

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -698,9 +698,7 @@
         //   step, because sometimes browser scrolls viewport because of the focused element?
         //   Well, the [tab] key by default navigates around focusable elements, so clicking
         //   it very often caused scrolling to focused element and breaking impress.js
-        //   positioning. I didn't want to just prevent this default action, so I used [tab]
-        //   as another way to moving to next step... And yes, I know that for the sake of
-        //   consistency I should add [shift+tab] as opposite action...
+        //   positioning. 
         document.addEventListener("keyup", function ( event ) {
             if ( event.keyCode === 9 || ( event.keyCode >= 32 && event.keyCode <= 34 ) || (event.keyCode >= 37 && event.keyCode <= 40) ) {
                 switch( event.keyCode ) {
@@ -709,7 +707,6 @@
                     case 38: // up
                              api.prev();
                              break;
-                    case 9:  // tab
                     case 32: // space
                     case 34: // pg down
                     case 39: // right


### PR DESCRIPTION
Currently, TAB keyUp event moves to next slide - causing problem when the user is coming from another application through Alt+TAB. The sequence is as follow:
   - user on application A
   - user presses Alt+TAB
   - user releases Alt
   - focus is set on the browser by OS
   - user releases TAB
   - Impress moves to next slide

The solution is thus to still prevent defaults when TAB is released, but not move to the next slide.

   