### PR TITLE
Require an issue for a feature Pull Request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,11 @@ Guidelines:
 Pull Requests
 -------------
 
-If you have fixed a bug or implemented a feature that you'd like to share, send your [Pull Request](https://help.github.com/articles/using-pull-requests/) against the [master branch]
-(https://github.com/bartaz/impress.js/tree/master). But remember that the team will only accept code that fits the purpose of impress.js
+[Pull Requests](https://help.github.com/articles/using-pull-requests/) should be opened against the [master branch]
+(https://github.com/bartaz/impress.js/tree/master). But remember that the team will only accept code that fits the purpose of impress.js.
 
 Guidelines:
 
+* If proposing a feature, make sure to discuss that as an issue first.
 * Create a new [topic branch](https://github.com/dchelimsky/rspec/wiki/Topic-Branches) for every separate change you make.
 * Make sure impress.js runs successfully on as many browsers as you can test.


### PR DESCRIPTION
As you can see in the [closed Pull Requests](https://github.com/impress/impress.js/pulls?q=is%3Apr+is%3Aclosed), there is a lot of feature requests that should have been discussed as an issue first. Starting with the Pull Request for the feature to be discarded later creates a bad situation for the project maintainer and the OP.

Documenting that we require an issue first serves as a justification for closing Pull Requests without having to discard them immediately.

The good thing about issues is that you can request visual examples, pseudo-code samples, and other stuff that would just create noise in the PR instead of focusing only in the code review.

This PR documents that requirements and make it easy for triage since it is just to point out the requirements.

ping @impress/mergers 