### PR TITLE
Document support only for evergreen desktop browsers based on feature detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,69 +64,11 @@ It's an (un)fortunate coincidence that a Open/LibreOffice presentation tool is c
 BROWSER SUPPORT
 -----------------
 
-### TL;DR;
+This project supports only the major [evergreen](http://eisenbergeffect.bluespire.com/evergreen-browsers/) desktop browsers that have implemented:
 
-Currently impress.js works fine in latest Chrome/Chromium browser, Safari 5.1 and Firefox 10.
-With addition of some HTML5 polyfills (see below for details) it should work in Internet Explorer 10, 11 and Edge.
-It doesn't work in Opera, as it doesn't support CSS 3D transforms.
-
-If you find impress.js working on other browsers, feel free to tell us and we'll update this documentation.
-
-As a presentation tool it was not developed with mobile browsers in mind, but some tablets are good
-enough to run it, so it should work quite well on iPad (iOS 5, or iOS 4 with HTML5 polyfills) and
-Blackberry Playbook. Inform us of any bug and we will try to fix this.
-
-### Still interested? Read more...
-
-Additionally for the animations to run smoothly it's required to have hardware
-acceleration support in your browser. This depends on the browser, your operating
-system and even kind of graphic hardware you have in your machine.
-
-For browsers not supporting CSS3 3D transforms impress.js adds `impress-not-supported`
-class on `#impress` element, so fallback styles can be applied to make all the content accessible.
-
-
-### Even more explanation and technical stuff
-
-Let's put this straight -- wide browser support was (and is) not on top of my priority list for
-impress.js. It's built on top of fresh technologies that just start to appear in the browsers
-and I'd like to rather look forward and develop for the future than being slowed down by the past.
-
-But it's not "hard-coded" for any particular browser or engine. If any browser in future will
-support features required to run impress.js, it will just begin to work there without changes in
-the code.
-
-From technical point of view all the positioning of presentation elements in 3D requires CSS 3D
-transforms support. Transitions between presentation steps are based on CSS transitions.
-So these two features are required by impress.js to display presentation correctly.
-
-Unfortunately the support for CSS 3D transforms and transitions is not enough for animations to
-run smoothly. If the browser doesn't support hardware acceleration or the graphic card is not
-good enough the transitions will be laggy.
-
-Additionally the code of impress.js relies on APIs proposed in HTML5 specification, including
-`classList` and `dataset` APIs. If they are not available in the browser, impress.js will not work.
-
-Fortunately, as these are JavaScript APIs there are polyfill libraries that patch older browsers
-with these APIs.
-
-For example IE10 is said to support CSS 3D transforms and transitions, but it doesn't have `dataset`
-APIs implemented at the moment. So including polyfill libraries *should* help IE10 with running
-impress.js.
-
-
-### And few more details about mobile support
-
-Mobile browsers are currently not supported. Even Android browsers that support CSS 3D transforms are
-forced into fallback view at this point.
-
-Fortunately some tablets seem to have good enough hardware support and browsers to handle it.
-Currently impress.js presentations should work on iPad and Blackberry Playbook.
-
-In theory iPhone should also be able to run it (as it runs the same software as iPad), but I haven't
-found a good way to handle its small screen.
-
-Also note that iOS supports `classList` and `dataset` APIs starting with version 5, so iOS 4.X and older
-requires polyfills to work.
+* [DataSet API](http://caniuse.com/#search=dataset)
+* [ClassList API](http://caniuse.com/#search=classlist)
+* [CSS 3D Transforms](http://caniuse.com/#search=css%203d)
+* [CSS Transitions](http://caniuse.com/#search=css%20transition)
 
 Copyright 2011-2016 Bartek Szopka - Released under the MIT [License](LICENSE)


### PR DESCRIPTION
I don't think we should be focusing effort in maintaining this documentation. Stating that it works in the latest browsers and increase the support as the need arises based on developers feedback is the best thing we can do for now IMHO.

This also reduces a lot of content in the README, making it possible to focus in more important stuff than with needless details.

Ping @impress/mergers for review.