### PR TITLE
Move creds to circle-ci accnt config.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,6 @@ machine:
   node:
     version: 6
 
-dependencies:
-  pre:
-    - openssl aes-256-cbc -d -in sauce-encrypted-env-vars -k $SAUCE_DECRYPT_KEY >> ~/.circlerc
-
 test:
   override:
     - npm run lint -s

--- a/sauce-encrypted-env-vars
+++ b/sauce-encrypted-env-vars
@@ -1,2 +1,0 @@
-Salted__£¾IV¬]O‚èÄÊõ:bi»{7CÄü0è…"JB><¾kmðÉ­/É¬öCLnòØ]¢>\Ü•±».£ÙÊm"…K²øZÏs9Ÿ’Qš¦¬%ÛvðX
-7Á•eXŽcÏá¥»!w


### PR DESCRIPTION
This PR moves creds to the circle-ci accnt config to simplify things and make it work for PRs.
Related to #91. Sauce creds are pretty low worry so the ways things are is a little overkill.