### PR TITLE
Proposal of documenting a high-level Roadmap

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+Roadmap
+-------
+
+impress.js have [an strategic Roadmap](https://github.com/impress/impress.js/wiki/Roadmap) with a high-level overview of what we plan for the future. When proposing changes for improvement, make sure it goes in that direction, even if it's a very small step.
+
+Since this is entirely a community effort, feel free to [create an issue](https://github.com/impress/impress.js/issues) and propose changes on that Roadmap.
+
 Issues
 ------
 


### PR DESCRIPTION
I have created [a Roadmap in the wiki](https://github.com/impress/impress.js/wiki/Roadmap) based on what we have discussed so far since 2013 and I would like to propose documenting that so that the strategy is clear for future contributors.

Is the Roadmap correct? Should we document this?

Looking for feedback.

Ping @impress/mergers