### PR TITLE
fixed bug where clicking on an element that is not part of the canvas…

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -699,6 +699,7 @@
         // or anything. `impress:init` event data gives you everything you
         // need to control the presentation that was just initialized.
         var api = event.detail.api;
+        var root = event.target;
 
         // KEYBOARD NAVIGATION HANDLERS
 
@@ -799,7 +800,13 @@
         // Touch handler to detect taps on the left and right side of the screen
         // based on awesome work of @hakimel: https://github.com/hakimel/reveal.js
         document.addEventListener( "touchstart", function( event ) {
-            if ( event.touches.length === 1 ) {
+            var target = event.target;
+
+            while ( target !== root  && target.parentNode ) {
+                target = target.parentNode;
+            }
+
+            if ( target === root && event.touches.length === 1 ) {
                 var x = event.touches[ 0 ].clientX,
                     width = window.innerWidth * 0.3,
                     result = null;


### PR DESCRIPTION
… would cause the impress to go to the next or previous slide

Fixes #613

**Make sure these boxes are checked before submitting your Pull Request, thank you!**

- [x] I have read and complied with the [Pull Request Contributing Guidelines](https://github.com/impress/impress.js/blob/master/CONTRIBUTING.md#pull-requests).
- [x] I checked if an [an issue](https://github.com/impress/impress.js/issues) is necessary for my Pull Request and made sure it exists.
- [x] I have created a [topic branch](https://github.com/dchelimsky/rspec/wiki/Topic-Branches).
- [x] I have used the [Search Tool](https://github.com/impress/impress.js/search?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen&type=Issues) to make sure there are no open Pull Requests fixing the same thing.