### PR TITLE
keep the raw value of data.[], so that user could custom the unit.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -297,9 +297,9 @@
             var data = el.dataset,
                 step = {
                     translate: {
-                        x: toNumber( data.x ),
-                        y: toNumber( data.y ),
-                        z: toNumber( data.z )
+                        x: toNumber( data.x, data.x ),
+                        y: toNumber( data.y, data.y ),
+                        z: toNumber( data.z, data.z )
                     },
                     rotate: {
                         x: toNumber( data.rotateX ),


### PR DESCRIPTION
keep the raw value of data.[] (instead of `0` if it isn't a valid number), so that user could use my custom unit instead of always 'px'.

I think, it's unnecessary that force to require a number value for data-x/y/z, witch used to translate the `step` div. becauce, user may need to use some other unit instead of `px`. For example, if we allow the usage like `data-x="100vw"` , then user can easily to placed the step elements closely when they are all fullscreen size in active.

Maybe something I'm not take account, but I think allow the custom unit is necessary. if the method `keep the raw value` that this pull-request used would cause some problem that I don't realize, we can use other ways, such as provide an interface to set set unit.