### PR TITLE
Common libraries in src/lib

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -229,6 +229,31 @@ rootElement.addEventListener( "impress:init", function() {
 impress().init();
 ```
 
+#### .tear()
+
+Resets the DOM to its original state, as it was before `init()` was called.
+
+This can be used to "unload" impress.js. A particular use case for this is, if you want to do
+dynamic changes to the presentation, you can do a teardown, apply changes, then call `init()`
+again. (In most cases, this will not cause flickering or other visible effects to the user,
+beyond the intended dynamic changes.)
+
+**Example:**
+
+```JavaScript
+impress().tear();
+```
+
+**Example:**
+
+```JavaScript
+var rootElement = document.getElementById( "impress" );
+rootElement.addEventListener( "impress:init", function() {
+  console.log( "Impress init" );
+});
+impress().init();
+```
+
 #### .next()
 
 Navigates to the next step of the presentation using the [`goto()` function](#impressgotostepindexstepelementidstepelement-duration).

--- a/build.js
+++ b/build.js
@@ -2,6 +2,9 @@ var buildify = require('buildify');
 
 buildify()
   .load('src/impress.js')
+  // Libraries from src/lib
+  .concat(['src/lib/gc.js'])
+  // Plugins from src/plugins
   .concat(['src/plugins/navigation/navigation.js',
            'src/plugins/resize/resize.js'])
   .save('js/impress.js');

--- a/build.js
+++ b/build.js
@@ -4,6 +4,7 @@ buildify()
   .load('src/impress.js')
   // Libraries from src/lib
   .concat(['src/lib/gc.js'])
+  .concat(['src/lib/util.js'])
   // Plugins from src/plugins
   .concat(['src/plugins/navigation/navigation.js',
            'src/plugins/resize/resize.js'])

--- a/js/impress.js
+++ b/js/impress.js
@@ -20,6 +20,7 @@
 // Let me show you the cogs that make impress.js run...
 ( function( document, window ) {
     "use strict";
+    var lib;
 
     // HELPER FUNCTIONS
 
@@ -53,12 +54,6 @@
 
     } )();
 
-    // `arrayify` takes an array-like object and turns it into real Array
-    // to make all the Array.prototype goodness available.
-    var arrayify = function( a ) {
-        return [].slice.call( a );
-    };
-
     // `css` function applies the styles given in `props` object to the element
     // given as `el`. It runs all property names through `pfx` function to make
     // sure proper prefixed version of the property is used.
@@ -73,40 +68,6 @@
             }
         }
         return el;
-    };
-
-    // `toNumber` takes a value given as `numeric` parameter and tries to turn
-    // it into a number. If it is not possible it returns 0 (or other value
-    // given as `fallback`).
-    var toNumber = function( numeric, fallback ) {
-        return isNaN( numeric ) ? ( fallback || 0 ) : Number( numeric );
-    };
-
-    // `byId` returns element with given `id` - you probably have guessed that ;)
-    var byId = function( id ) {
-        return document.getElementById( id );
-    };
-
-    // `$` returns first element for given CSS `selector` in the `context` of
-    // the given element or whole document.
-    var $ = function( selector, context ) {
-        context = context || document;
-        return context.querySelector( selector );
-    };
-
-    // `$$` return an array of elements for given CSS `selector` in the `context` of
-    // the given element or whole document.
-    var $$ = function( selector, context ) {
-        context = context || document;
-        return arrayify( context.querySelectorAll( selector ) );
-    };
-
-    // `triggerEvent` builds a custom DOM event with given `eventName` and `detail` data
-    // and triggers it on element given as `el`.
-    var triggerEvent = function( el, eventName, detail ) {
-        var event = document.createEvent( "CustomEvent" );
-        event.initCustomEvent( eventName, true, true, detail );
-        el.dispatchEvent( event );
     };
 
     // `translate` builds a translate transform string for given data.
@@ -128,15 +89,6 @@
     // `scale` builds a scale transform string for given data.
     var scale = function( s ) {
         return " scale(" + s + ") ";
-    };
-
-    // `getElementFromHash` returns an element located by id from hash part of
-    // window location.
-    var getElementFromHash = function() {
-
-        // Get id from url # by removing `#` or `#/` from the beginning,
-        // so both "fallback" `#slide-id` and "enhanced" `#/slide-id` will work
-        return byId( window.location.hash.replace( /^#\/?/, "" ) );
     };
 
     // `computeWindowScale` counts the scale factor between window size and size
@@ -236,7 +188,7 @@
         }
 
         // The gc library depends on being initialized before we do any changes to DOM.
-        var lib = initLibraries( rootId );
+        lib = initLibraries( rootId );
 
         body.classList.remove( "impress-not-supported" );
         body.classList.add( "impress-supported" );
@@ -260,7 +212,7 @@
         var windowScale = null;
 
         // Root presentation elements
-        var root = byId( rootId );
+        var root = lib.util.byId( rootId );
         var canvas = document.createElement( "div" );
 
         var initialized = false;
@@ -281,7 +233,7 @@
         // last entered step.
         var onStepEnter = function( step ) {
             if ( lastEntered !== step ) {
-                triggerEvent( step, "impress:stepenter" );
+                lib.util.triggerEvent( step, "impress:stepenter" );
                 lastEntered = step;
             }
         };
@@ -291,7 +243,7 @@
         // last entered step.
         var onStepLeave = function( step ) {
             if ( lastEntered === step ) {
-                triggerEvent( step, "impress:stepleave" );
+                lib.util.triggerEvent( step, "impress:stepleave" );
                 lastEntered = null;
             }
         };
@@ -302,16 +254,16 @@
             var data = el.dataset,
                 step = {
                     translate: {
-                        x: toNumber( data.x ),
-                        y: toNumber( data.y ),
-                        z: toNumber( data.z )
+                        x: lib.util.toNumber( data.x ),
+                        y: lib.util.toNumber( data.y ),
+                        z: lib.util.toNumber( data.z )
                     },
                     rotate: {
-                        x: toNumber( data.rotateX ),
-                        y: toNumber( data.rotateY ),
-                        z: toNumber( data.rotateZ || data.rotate )
+                        x: lib.util.toNumber( data.rotateX ),
+                        y: lib.util.toNumber( data.rotateY ),
+                        z: lib.util.toNumber( data.rotateZ || data.rotate )
                     },
-                    scale: toNumber( data.scale, 1 ),
+                    scale: lib.util.toNumber( data.scale, 1 ),
                     el: el
                 };
 
@@ -337,7 +289,7 @@
 
             // First we set up the viewport for mobile devices.
             // For some reason iPad goes nuts when it is not done properly.
-            var meta = $( "meta[name='viewport']" ) || document.createElement( "meta" );
+            var meta = lib.util.$( "meta[name='viewport']" ) || document.createElement( "meta" );
             meta.content = "width=device-width, minimum-scale=1, maximum-scale=1, user-scalable=no";
             if ( meta.parentNode !== document.head ) {
                 meta.name = "viewport";
@@ -347,12 +299,12 @@
             // Initialize configuration object
             var rootData = root.dataset;
             config = {
-                width: toNumber( rootData.width, defaults.width ),
-                height: toNumber( rootData.height, defaults.height ),
-                maxScale: toNumber( rootData.maxScale, defaults.maxScale ),
-                minScale: toNumber( rootData.minScale, defaults.minScale ),
-                perspective: toNumber( rootData.perspective, defaults.perspective ),
-                transitionDuration: toNumber(
+                width: lib.util.toNumber( rootData.width, defaults.width ),
+                height: lib.util.toNumber( rootData.height, defaults.height ),
+                maxScale: lib.util.toNumber( rootData.maxScale, defaults.maxScale ),
+                minScale: lib.util.toNumber( rootData.minScale, defaults.minScale ),
+                perspective: lib.util.toNumber( rootData.perspective, defaults.perspective ),
+                transitionDuration: lib.util.toNumber(
                   rootData.transitionDuration, defaults.transitionDuration
                 )
             };
@@ -360,7 +312,7 @@
             windowScale = computeWindowScale( config );
 
             // Wrap steps with "canvas" element
-            arrayify( root.childNodes ).forEach( function( el ) {
+            lib.util.arrayify( root.childNodes ).forEach( function( el ) {
                 canvas.appendChild( el );
             } );
             root.appendChild( canvas );
@@ -393,7 +345,7 @@
             body.classList.add( "impress-enabled" );
 
             // Get and init steps
-            steps = $$( ".step", root );
+            steps = lib.util.$$( ".step", root );
             steps.forEach( initStep );
 
             // Set a default initial state of the canvas
@@ -405,7 +357,8 @@
 
             initialized = true;
 
-            triggerEvent( root, "impress:init", { api: roots[ "impress-root-" + rootId ] } );
+            lib.util.triggerEvent( root, "impress:init",
+                                   { api: roots[ "impress-root-" + rootId ] } );
         };
 
         // `getStep` is a helper function that returns a step element defined by parameter.
@@ -416,7 +369,7 @@
             if ( typeof step === "number" ) {
                 step = step < 0 ? steps[ steps.length + step ] : steps[ step ];
             } else if ( typeof step === "string" ) {
-                step = byId( step );
+                step = lib.util.byId( step );
             }
             return ( step && step.id && stepsData[ "impress-" + step.id ] ) ? step : null;
         };
@@ -478,7 +431,7 @@
             // with scaling down and move and rotation are delayed.
             var zoomin = target.scale >= currentState.scale;
 
-            duration = toNumber( duration, config.transitionDuration );
+            duration = lib.util.toNumber( duration, config.transitionDuration );
             var delay = ( duration / 2 );
 
             // If the same step is re-selected, force computing window scaling,
@@ -650,13 +603,13 @@
                 //
                 // To avoid this we store last entered hash and compare.
                 if ( window.location.hash !== lastHash ) {
-                    goto( getElementFromHash() );
+                    goto( lib.util.getElementFromHash() );
                 }
             }, false );
 
             // START
             // by selecting step defined in url or first step of the presentation
-            goto( getElementFromHash() || steps[ 0 ], 0 );
+            goto( lib.util.getElementFromHash() || steps[ 0 ], 0 );
         }, false );
 
         body.classList.add( "impress-disabled" );
@@ -947,6 +900,104 @@
 } )( document, window );
 
 /**
+ * Common utility functions
+ *
+ * Copyright 2011-2012 Bartek Szopka (@bartaz)
+ * Henrik Ingo (c) 2016
+ * MIT License
+ */
+
+( function( document, window ) {
+    "use strict";
+    var roots = [];
+
+    var libraryFactory = function( rootId ) {
+        if ( roots[ rootId ] ) {
+            return roots[ rootId ];
+        }
+
+        // `$` returns first element for given CSS `selector` in the `context` of
+        // the given element or whole document.
+        var $ = function( selector, context ) {
+            context = context || document;
+            return context.querySelector( selector );
+        };
+
+        // `$$` return an array of elements for given CSS `selector` in the `context` of
+        // the given element or whole document.
+        var $$ = function( selector, context ) {
+            context = context || document;
+            return arrayify( context.querySelectorAll( selector ) );
+        };
+
+        // `arrayify` takes an array-like object and turns it into real Array
+        // to make all the Array.prototype goodness available.
+        var arrayify = function( a ) {
+            return [].slice.call( a );
+        };
+
+        // `byId` returns element with given `id` - you probably have guessed that ;)
+        var byId = function( id ) {
+            return document.getElementById( id );
+        };
+
+        // `getElementFromHash` returns an element located by id from hash part of
+        // window location.
+        var getElementFromHash = function() {
+
+            // Get id from url # by removing `#` or `#/` from the beginning,
+            // so both "fallback" `#slide-id` and "enhanced" `#/slide-id` will work
+            return byId( window.location.hash.replace( /^#\/?/, "" ) );
+        };
+
+        // Throttling function calls, by Remy Sharp
+        // http://remysharp.com/2010/07/21/throttling-function-calls/
+        var throttle = function( fn, delay ) {
+            var timer = null;
+            return function() {
+                var context = this, args = arguments;
+                window.clearTimeout( timer );
+                timer = window.setTimeout( function() {
+                    fn.apply( context, args );
+                }, delay );
+            };
+        };
+
+        // `toNumber` takes a value given as `numeric` parameter and tries to turn
+        // it into a number. If it is not possible it returns 0 (or other value
+        // given as `fallback`).
+        var toNumber = function( numeric, fallback ) {
+            return isNaN( numeric ) ? ( fallback || 0 ) : Number( numeric );
+        };
+
+        // `triggerEvent` builds a custom DOM event with given `eventName` and `detail` data
+        // and triggers it on element given as `el`.
+        var triggerEvent = function( el, eventName, detail ) {
+            var event = document.createEvent( "CustomEvent" );
+            event.initCustomEvent( eventName, true, true, detail );
+            el.dispatchEvent( event );
+        };
+
+        var lib = {
+            $: $,
+            $$: $$,
+            arrayify: arrayify,
+            byId: byId,
+            getElementFromHash: getElementFromHash,
+            throttle: throttle,
+            toNumber: toNumber,
+            triggerEvent: triggerEvent
+        };
+        roots[ rootId ] = lib;
+        return lib;
+    };
+
+    // Let impress core know about the existence of this library
+    window.impress.addLibraryFactory( { util: libraryFactory } );
+
+} )( document, window );
+
+/**
  * Navigation events plugin
  *
  * As you can see this part is separate from the impress.js core code.
@@ -973,12 +1024,6 @@
 ( function( document ) {
     "use strict";
 
-    var triggerEvent = function( el, eventName, detail ) {
-        var event = document.createEvent( "CustomEvent" );
-        event.initCustomEvent( eventName, true, true, detail );
-        el.dispatchEvent( event );
-    };
-
     // Wait for impress.js to be initialized
     document.addEventListener( "impress:init", function( event ) {
 
@@ -988,6 +1033,7 @@
         // need to control the presentation that was just initialized.
         var api = event.detail.api;
         var gc = api.lib.gc;
+        var util = api.lib.util;
 
         // Supported keys are:
         // [space] - quite common in presentation software to move forward
@@ -1114,8 +1160,9 @@
         }, false );
 
         // Add a line to the help popup
-        triggerEvent( document, "impress:help:add",
-                      { command: "Left &amp; Right", text: "Previous &amp; Next step", row: 1 } );
+        util.triggerEvent( document, "impress:help:add", { command: "Left &amp; Right",
+                                                           text: "Previous &amp; Next step",
+                                                           row: 1 } );
 
     }, false );
 
@@ -1142,25 +1189,12 @@
 ( function( document, window ) {
     "use strict";
 
-    // Throttling function calls, by Remy Sharp
-    // http://remysharp.com/2010/07/21/throttling-function-calls/
-    var throttle = function( fn, delay ) {
-        var timer = null;
-        return function() {
-            var context = this, args = arguments;
-            window.clearTimeout( timer );
-            timer = window.setTimeout( function() {
-                fn.apply( context, args );
-            }, delay );
-        };
-    };
-
     // Wait for impress.js to be initialized
     document.addEventListener( "impress:init", function( event ) {
         var api = event.detail.api;
 
         // Rescale presentation when window is resized
-        api.lib.gc.addEventListener( window, "resize", throttle( function() {
+        api.lib.gc.addEventListener( window, "resize", api.lib.util.throttle( function() {
 
             // Force going to active step again, to trigger rescaling
             api.goto( document.querySelector( ".step.active" ), 500 );

--- a/src/impress.js
+++ b/src/impress.js
@@ -20,6 +20,7 @@
 // Let me show you the cogs that make impress.js run...
 ( function( document, window ) {
     "use strict";
+    var lib;
 
     // HELPER FUNCTIONS
 
@@ -53,12 +54,6 @@
 
     } )();
 
-    // `arrayify` takes an array-like object and turns it into real Array
-    // to make all the Array.prototype goodness available.
-    var arrayify = function( a ) {
-        return [].slice.call( a );
-    };
-
     // `css` function applies the styles given in `props` object to the element
     // given as `el`. It runs all property names through `pfx` function to make
     // sure proper prefixed version of the property is used.
@@ -73,40 +68,6 @@
             }
         }
         return el;
-    };
-
-    // `toNumber` takes a value given as `numeric` parameter and tries to turn
-    // it into a number. If it is not possible it returns 0 (or other value
-    // given as `fallback`).
-    var toNumber = function( numeric, fallback ) {
-        return isNaN( numeric ) ? ( fallback || 0 ) : Number( numeric );
-    };
-
-    // `byId` returns element with given `id` - you probably have guessed that ;)
-    var byId = function( id ) {
-        return document.getElementById( id );
-    };
-
-    // `$` returns first element for given CSS `selector` in the `context` of
-    // the given element or whole document.
-    var $ = function( selector, context ) {
-        context = context || document;
-        return context.querySelector( selector );
-    };
-
-    // `$$` return an array of elements for given CSS `selector` in the `context` of
-    // the given element or whole document.
-    var $$ = function( selector, context ) {
-        context = context || document;
-        return arrayify( context.querySelectorAll( selector ) );
-    };
-
-    // `triggerEvent` builds a custom DOM event with given `eventName` and `detail` data
-    // and triggers it on element given as `el`.
-    var triggerEvent = function( el, eventName, detail ) {
-        var event = document.createEvent( "CustomEvent" );
-        event.initCustomEvent( eventName, true, true, detail );
-        el.dispatchEvent( event );
     };
 
     // `translate` builds a translate transform string for given data.
@@ -128,15 +89,6 @@
     // `scale` builds a scale transform string for given data.
     var scale = function( s ) {
         return " scale(" + s + ") ";
-    };
-
-    // `getElementFromHash` returns an element located by id from hash part of
-    // window location.
-    var getElementFromHash = function() {
-
-        // Get id from url # by removing `#` or `#/` from the beginning,
-        // so both "fallback" `#slide-id` and "enhanced" `#/slide-id` will work
-        return byId( window.location.hash.replace( /^#\/?/, "" ) );
     };
 
     // `computeWindowScale` counts the scale factor between window size and size
@@ -236,7 +188,7 @@
         }
 
         // The gc library depends on being initialized before we do any changes to DOM.
-        var lib = initLibraries( rootId );
+        lib = initLibraries( rootId );
 
         body.classList.remove( "impress-not-supported" );
         body.classList.add( "impress-supported" );
@@ -260,7 +212,7 @@
         var windowScale = null;
 
         // Root presentation elements
-        var root = byId( rootId );
+        var root = lib.util.byId( rootId );
         var canvas = document.createElement( "div" );
 
         var initialized = false;
@@ -281,7 +233,7 @@
         // last entered step.
         var onStepEnter = function( step ) {
             if ( lastEntered !== step ) {
-                triggerEvent( step, "impress:stepenter" );
+                lib.util.triggerEvent( step, "impress:stepenter" );
                 lastEntered = step;
             }
         };
@@ -291,7 +243,7 @@
         // last entered step.
         var onStepLeave = function( step ) {
             if ( lastEntered === step ) {
-                triggerEvent( step, "impress:stepleave" );
+                lib.util.triggerEvent( step, "impress:stepleave" );
                 lastEntered = null;
             }
         };
@@ -302,16 +254,16 @@
             var data = el.dataset,
                 step = {
                     translate: {
-                        x: toNumber( data.x ),
-                        y: toNumber( data.y ),
-                        z: toNumber( data.z )
+                        x: lib.util.toNumber( data.x ),
+                        y: lib.util.toNumber( data.y ),
+                        z: lib.util.toNumber( data.z )
                     },
                     rotate: {
-                        x: toNumber( data.rotateX ),
-                        y: toNumber( data.rotateY ),
-                        z: toNumber( data.rotateZ || data.rotate )
+                        x: lib.util.toNumber( data.rotateX ),
+                        y: lib.util.toNumber( data.rotateY ),
+                        z: lib.util.toNumber( data.rotateZ || data.rotate )
                     },
-                    scale: toNumber( data.scale, 1 ),
+                    scale: lib.util.toNumber( data.scale, 1 ),
                     el: el
                 };
 
@@ -337,7 +289,7 @@
 
             // First we set up the viewport for mobile devices.
             // For some reason iPad goes nuts when it is not done properly.
-            var meta = $( "meta[name='viewport']" ) || document.createElement( "meta" );
+            var meta = lib.util.$( "meta[name='viewport']" ) || document.createElement( "meta" );
             meta.content = "width=device-width, minimum-scale=1, maximum-scale=1, user-scalable=no";
             if ( meta.parentNode !== document.head ) {
                 meta.name = "viewport";
@@ -347,12 +299,12 @@
             // Initialize configuration object
             var rootData = root.dataset;
             config = {
-                width: toNumber( rootData.width, defaults.width ),
-                height: toNumber( rootData.height, defaults.height ),
-                maxScale: toNumber( rootData.maxScale, defaults.maxScale ),
-                minScale: toNumber( rootData.minScale, defaults.minScale ),
-                perspective: toNumber( rootData.perspective, defaults.perspective ),
-                transitionDuration: toNumber(
+                width: lib.util.toNumber( rootData.width, defaults.width ),
+                height: lib.util.toNumber( rootData.height, defaults.height ),
+                maxScale: lib.util.toNumber( rootData.maxScale, defaults.maxScale ),
+                minScale: lib.util.toNumber( rootData.minScale, defaults.minScale ),
+                perspective: lib.util.toNumber( rootData.perspective, defaults.perspective ),
+                transitionDuration: lib.util.toNumber(
                   rootData.transitionDuration, defaults.transitionDuration
                 )
             };
@@ -360,7 +312,7 @@
             windowScale = computeWindowScale( config );
 
             // Wrap steps with "canvas" element
-            arrayify( root.childNodes ).forEach( function( el ) {
+            lib.util.arrayify( root.childNodes ).forEach( function( el ) {
                 canvas.appendChild( el );
             } );
             root.appendChild( canvas );
@@ -393,7 +345,7 @@
             body.classList.add( "impress-enabled" );
 
             // Get and init steps
-            steps = $$( ".step", root );
+            steps = lib.util.$$( ".step", root );
             steps.forEach( initStep );
 
             // Set a default initial state of the canvas
@@ -405,7 +357,8 @@
 
             initialized = true;
 
-            triggerEvent( root, "impress:init", { api: roots[ "impress-root-" + rootId ] } );
+            lib.util.triggerEvent( root, "impress:init",
+                                   { api: roots[ "impress-root-" + rootId ] } );
         };
 
         // `getStep` is a helper function that returns a step element defined by parameter.
@@ -416,7 +369,7 @@
             if ( typeof step === "number" ) {
                 step = step < 0 ? steps[ steps.length + step ] : steps[ step ];
             } else if ( typeof step === "string" ) {
-                step = byId( step );
+                step = lib.util.byId( step );
             }
             return ( step && step.id && stepsData[ "impress-" + step.id ] ) ? step : null;
         };
@@ -478,7 +431,7 @@
             // with scaling down and move and rotation are delayed.
             var zoomin = target.scale >= currentState.scale;
 
-            duration = toNumber( duration, config.transitionDuration );
+            duration = lib.util.toNumber( duration, config.transitionDuration );
             var delay = ( duration / 2 );
 
             // If the same step is re-selected, force computing window scaling,
@@ -650,13 +603,13 @@
                 //
                 // To avoid this we store last entered hash and compare.
                 if ( window.location.hash !== lastHash ) {
-                    goto( getElementFromHash() );
+                    goto( lib.util.getElementFromHash() );
                 }
             }, false );
 
             // START
             // by selecting step defined in url or first step of the presentation
-            goto( getElementFromHash() || steps[ 0 ], 0 );
+            goto( lib.util.getElementFromHash() || steps[ 0 ], 0 );
         }, false );
 
         body.classList.add( "impress-disabled" );

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,105 @@
+Impress.js Libraries
+====================
+
+The `src/lib/*.js` files contain library functions. The main difference to plugins is that:
+
+1. Libraries are closer to the impress.js core than plugins (arguably a subjective metric)
+2. Libraries are common utility functions used by many plugins
+3. Libraries are called synchronously, which is why the event based paradigm that plugins use to
+   communicate isn't useful.
+
+Plugins can access libraries via the API:
+
+    var api;
+    document.addEventListener( "impress:init", function(event){
+        api = event.detail.api;
+        api().lib.<libraryName>.<libaryFunction>();
+    });
+
+...which is equivalent to:
+
+    impress().lib.<libraryName>.<libraryFunction>();
+
+Implementing a library
+----------------------
+
+1. Create a file under `src/lib/`.
+
+2. Start with the standard boilerplate documentation, and the (function(document, window){})(); 
+wrapper.
+
+3. The library should implement a factory function, and make its existence known to impress.js core:
+
+    window.impress.addLibraryFactory( { libName : libraryFactory} );
+
+4. The library function should return a similar API object as core `impress()` function does:
+
+    var libraryFactory = function(rootId) {
+        /* implement library functions ... */
+        
+        var lib = {
+            libFunction1: libFunction1,
+            libFunction2: libFunction2
+        }
+        return lib;
+    };
+
+5. While rarely used, impress.js actually supports multiple presentation root div elements on a
+single html page. Each of these have their own API object, identified by the root element id
+attribute:
+
+    impress("other-root-id").init();
+
+(The default rootId obviously is `"impress"`.)
+
+Libraries MUST implement this support for multiple root elements as well. 
+
+- impress.js core will call the factory once for each separate root element being initialized via
+  `impress.init(rootId)`.
+- Any state that a library might hold, MUST be stored *per `rootId`*.
+- Note that as we now support also `impress(rootId).tear()`, the same root element might be
+  initialized more than once, and each of these MUST be treated as a new valid initialization.
+
+Putting all of the above together, a skeleton library file will look like:
+
+    /**
+    * Example library libName
+    *
+    * Henrik Ingo (c) 2016
+    * MIT License
+    */
+    (function ( document, window ) {
+        'use strict';
+        // Singleton library variables
+        var roots = [];
+        var singletonVar = {};
+        
+        var libraryFactory = function(rootId) {
+            if (roots["impress-root-" + rootId]) {
+                return roots["impress-root-" + rootId];
+            }
+            
+            // Per root global variables (instance variables?)
+            var instanceVar = {};
+
+            // LIBRARY FUNCTIONS
+            var libararyFunction1 = function () {
+                /* ... */
+            };
+            
+            var libararyFunction2 = function () {
+                /* ... */
+            };
+            
+            var lib = {
+                    libFunction1: libFunction1,
+                    libFunction2: libFunction2
+                }
+            roots["impress-root-" + rootId] = lib;
+            return lib;
+        };
+        
+        // Let impress core know about the existence of this library
+        window.impress.addLibraryFactory( { libName : libraryFactory } );
+        
+    })(document, window);

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -83,11 +83,11 @@ Putting all of the above together, a skeleton library file will look like:
             var instanceVar = {};
 
             // LIBRARY FUNCTIONS
-            var libararyFunction1 = function () {
+            var libraryFunction1 = function () {
                 /* ... */
             };
             
-            var libararyFunction2 = function () {
+            var libraryFunction2 = function () {
                 /* ... */
             };
             

--- a/src/lib/gc.js
+++ b/src/lib/gc.js
@@ -1,0 +1,229 @@
+/**
+ * Garbage collection utility
+ *
+ * This library allows plugins to add elements and event listeners they add to the DOM. The user
+ * can call `impress().lib.gc.teardown()` to cause all of them to be removed from DOM, so that
+ * the document is in the state it was before calling `impress().init()`.
+ *
+ * In addition to just adding elements and event listeners to the garbage collector, plugins
+ * can also register callback functions to do arbitrary cleanup upon teardown.
+ *
+ * Henrik Ingo (c) 2016
+ * MIT License
+ */
+
+( function( document, window ) {
+    "use strict";
+    var roots = [];
+    var rootsCount = 0;
+    var startingState = { roots: [] };
+
+    var libraryFactory = function( rootId ) {
+        if ( roots[ rootId ] ) {
+            return roots[ rootId ];
+        }
+
+        // Per root global variables (instance variables?)
+        var elementList = [];
+        var eventListenerList = [];
+        var callbackList = [];
+
+        recordStartingState( rootId );
+
+        // LIBRARY FUNCTIONS
+        // Below are definitions of the library functions we return at the end
+        var pushElement = function( element ) {
+            elementList.push( element );
+        };
+
+        // Convenience wrapper that combines DOM appendChild with gc.pushElement
+        var appendChild = function( parent, element ) {
+            parent.appendChild( element );
+            pushElement( element );
+        };
+
+        var pushEventListener = function( target, type, listenerFunction ) {
+            eventListenerList.push( { target:target, type:type, listener:listenerFunction } );
+        };
+
+        // Convenience wrapper that combines DOM addEventListener with gc.pushEventListener
+        var addEventListener = function( target, type, listenerFunction ) {
+            target.addEventListener( type, listenerFunction );
+            pushEventListener( target, type, listenerFunction );
+        };
+
+        // If the above utilities are not enough, plugins can add their own callback function
+        // to do arbitrary things.
+        var addCallback = function( callback ) {
+            callbackList.push( callback );
+        };
+        addCallback( function( rootId ) { resetStartingState( rootId ); } );
+
+        var teardown = function() {
+
+            // Execute the callbacks in LIFO order
+            var i; // Needed by jshint
+            for ( i = callbackList.length - 1; i >= 0; i-- ) {
+                callbackList[ i ]( rootId );
+            }
+            callbackList = [];
+            for ( i = 0; i < elementList.length; i++ ) {
+                elementList[ i ].parentElement.removeChild( elementList[ i ] );
+            }
+            elementList = [];
+            for ( i = 0; i < eventListenerList.length; i++ ) {
+                var target   = eventListenerList[ i ].target;
+                var type     = eventListenerList[ i ].type;
+                var listener = eventListenerList[ i ].listener;
+                target.removeEventListener( type, listener );
+            }
+        };
+
+        var lib = {
+            pushElement: pushElement,
+            appendChild: appendChild,
+            pushEventListener: pushEventListener,
+            addEventListener: addEventListener,
+            addCallback: addCallback,
+            teardown: teardown
+        };
+        roots[ rootId ] = lib;
+        rootsCount++;
+        return lib;
+    };
+
+    // Let impress core know about the existence of this library
+    window.impress.addLibraryFactory( { gc: libraryFactory } );
+
+    // CORE INIT
+    // The library factory (gc(rootId)) is called at the beginning of impress(rootId).init()
+    // For the purposes of teardown(), we can use this as an opportunity to save the state
+    // of a few things in the DOM in their virgin state, before impress().init() did anything.
+    // Note: These could also be recorded by the code in impress.js core as these values
+    // are changed, but in an effort to not deviate too much from upstream, I'm adding
+    // them here rather than the core itself.
+    var recordStartingState = function( rootId ) {
+        startingState.roots[ rootId ] = {};
+        startingState.roots[ rootId ].steps = [];
+
+        // Record whether the steps have an id or not
+        var steps = document.getElementById( rootId ).querySelectorAll( ".step" );
+        for ( var i = 0; i < steps.length; i++ ) {
+            var el = steps[ i ];
+            startingState.roots[ rootId ].steps.push( {
+                el: el,
+                id: el.getAttribute( "id" )
+            } );
+        }
+
+        // In the rare case of multiple roots, the following is changed on first init() and
+        // reset at last tear().
+        if ( rootsCount === 0 ) {
+            startingState.body = {};
+
+            // It is customary for authors to set body.class="impress-not-supported" as a starting
+            // value, which can then be removed by impress().init(). But it is not required.
+            // Remember whether it was there or not.
+            if ( document.body.classList.contains( "impress-not-supported" ) ) {
+                startingState.body.impressNotSupported = true;
+            } else {
+                startingState.body.impressNotSupported = false;
+            }
+
+            // If there's a <meta name="viewport"> element, its contents will be overwritten by init
+            var metas = document.head.querySelectorAll( "meta" );
+            for ( i = 0; i < metas.length; i++ ) {
+                var m = metas[ i ];
+                if ( m.name === "viewport" ) {
+                    startingState.meta = m.content;
+                }
+            }
+        }
+    };
+
+    // CORE TEARDOWN
+    var resetStartingState = function( rootId ) {
+
+        // Reset body element
+        document.body.classList.remove( "impress-enabled" );
+        document.body.classList.remove( "impress-disabled" );
+
+        var root = document.getElementById( rootId );
+        var activeId = root.querySelector( ".active" ).id;
+        document.body.classList.remove( "impress-on-" + activeId );
+
+        document.documentElement.style.height = "";
+        document.body.style.height = "";
+        document.body.style.overflow = "";
+
+        // Remove style values from the root and step elements
+        // Note: We remove the ones set by impress.js core. Otoh, we didn't preserve any original
+        // values. A more sophisticated implementation could keep track of original values and then
+        // reset those.
+        var steps = root.querySelectorAll( ".step" );
+        for ( var i = 0; i < steps.length; i++ ) {
+            steps[ i ].classList.remove( "future" );
+            steps[ i ].classList.remove( "past" );
+            steps[ i ].classList.remove( "present" );
+            steps[ i ].classList.remove( "active" );
+            steps[ i ].style.position = "";
+            steps[ i ].style.transform = "";
+            steps[ i ].style[ "transform-style" ] = "";
+        }
+        root.style.position = "";
+        root.style[ "transform-origin" ] = "";
+        root.style.transition = "";
+        root.style[ "transform-style" ] = "";
+        root.style.top = "";
+        root.style.left = "";
+        root.style.transform = "";
+
+        // Reset id of steps ("step-1" id's are auto generated)
+        steps = startingState.roots[ rootId ].steps;
+        var step;
+        while ( step = steps.pop() ) {
+            if ( step.id === null ) {
+                step.el.removeAttribute( "id" );
+            } else {
+                step.el.setAttribute( "id", step.id );
+            }
+        }
+        delete startingState.roots[ rootId ];
+
+        // Move step div elements away from canvas, then delete canvas
+        // Note: There's an implicit assumption here that the canvas div is the only child element
+        // of the root div. If there would be something else, it's gonna be lost.
+        var canvas = root.firstChild;
+        var canvasHTML = canvas.innerHTML;
+        root.innerHTML = canvasHTML;
+
+        if ( roots[ rootId ] !== undefined ) {
+            delete roots[ rootId ];
+            rootsCount--;
+        }
+        if ( rootsCount === 0 ) {
+
+            // In the rare case that more than one impress root elements were initialized, these
+            // are only reset when all are uninitialized.
+            document.body.classList.remove( "impress-supported" );
+            if ( startingState.body.impressNotSupported ) {
+                document.body.classList.add( "impress-not-supported" );
+            }
+
+            // We need to remove or reset the meta element inserted by impress.js
+            var metas = document.head.querySelectorAll( "meta" );
+            for ( i = 0; i < metas.length; i++ ) {
+                var m = metas[ i ];
+                if ( m.name === "viewport" ) {
+                    if ( startingState.meta !== undefined ) {
+                        m.content = startingState.meta;
+                    } else {
+                        m.parentElement.removeChild( m );
+                    }
+                }
+            }
+        }
+
+    };
+
+} )( document, window );

--- a/src/lib/gc.js
+++ b/src/lib/gc.js
@@ -31,34 +31,43 @@
         recordStartingState( rootId );
 
         // LIBRARY FUNCTIONS
-        // Below are definitions of the library functions we return at the end
+        // Definitions of the library functions we return as an object at the end
+
+        // `pushElement` adds a DOM element to the gc stack
         var pushElement = function( element ) {
             elementList.push( element );
         };
 
-        // Convenience wrapper that combines DOM appendChild with gc.pushElement
+        // `appendChild` is a convenience wrapper that combines DOM appendChild with gc.pushElement
         var appendChild = function( parent, element ) {
             parent.appendChild( element );
             pushElement( element );
         };
 
+        // `pushEventListener` adds an event listener to the gc stack
         var pushEventListener = function( target, type, listenerFunction ) {
             eventListenerList.push( { target:target, type:type, listener:listenerFunction } );
         };
 
-        // Convenience wrapper that combines DOM addEventListener with gc.pushEventListener
+        // `addEventListener` combines DOM addEventListener with gc.pushEventListener
         var addEventListener = function( target, type, listenerFunction ) {
             target.addEventListener( type, listenerFunction );
             pushEventListener( target, type, listenerFunction );
         };
 
-        // If the above utilities are not enough, plugins can add their own callback function
-        // to do arbitrary things.
+        // `addCallback` If the above utilities are not enough, plugins can add their own callback
+        // function to do arbitrary things.
         var addCallback = function( callback ) {
             callbackList.push( callback );
         };
         addCallback( function( rootId ) { resetStartingState( rootId ); } );
 
+        // `teardown` will
+        // - execute all callbacks in LIFO order
+        // - call `removeChild` on all DOM elements in LIFO order
+        // - call `removeEventListener` on all event listeners in LIFO order
+        // The goal of a teardown is to return to the same state that the DOM was before
+        // `impress().init()` was called.
         var teardown = function() {
 
             // Execute the callbacks in LIFO order

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,0 +1,97 @@
+/**
+ * Common utility functions
+ *
+ * Copyright 2011-2012 Bartek Szopka (@bartaz)
+ * Henrik Ingo (c) 2016
+ * MIT License
+ */
+
+( function( document, window ) {
+    "use strict";
+    var roots = [];
+
+    var libraryFactory = function( rootId ) {
+        if ( roots[ rootId ] ) {
+            return roots[ rootId ];
+        }
+
+        // `$` returns first element for given CSS `selector` in the `context` of
+        // the given element or whole document.
+        var $ = function( selector, context ) {
+            context = context || document;
+            return context.querySelector( selector );
+        };
+
+        // `$$` return an array of elements for given CSS `selector` in the `context` of
+        // the given element or whole document.
+        var $$ = function( selector, context ) {
+            context = context || document;
+            return arrayify( context.querySelectorAll( selector ) );
+        };
+
+        // `arrayify` takes an array-like object and turns it into real Array
+        // to make all the Array.prototype goodness available.
+        var arrayify = function( a ) {
+            return [].slice.call( a );
+        };
+
+        // `byId` returns element with given `id` - you probably have guessed that ;)
+        var byId = function( id ) {
+            return document.getElementById( id );
+        };
+
+        // `getElementFromHash` returns an element located by id from hash part of
+        // window location.
+        var getElementFromHash = function() {
+
+            // Get id from url # by removing `#` or `#/` from the beginning,
+            // so both "fallback" `#slide-id` and "enhanced" `#/slide-id` will work
+            return byId( window.location.hash.replace( /^#\/?/, "" ) );
+        };
+
+        // Throttling function calls, by Remy Sharp
+        // http://remysharp.com/2010/07/21/throttling-function-calls/
+        var throttle = function( fn, delay ) {
+            var timer = null;
+            return function() {
+                var context = this, args = arguments;
+                window.clearTimeout( timer );
+                timer = window.setTimeout( function() {
+                    fn.apply( context, args );
+                }, delay );
+            };
+        };
+
+        // `toNumber` takes a value given as `numeric` parameter and tries to turn
+        // it into a number. If it is not possible it returns 0 (or other value
+        // given as `fallback`).
+        var toNumber = function( numeric, fallback ) {
+            return isNaN( numeric ) ? ( fallback || 0 ) : Number( numeric );
+        };
+
+        // `triggerEvent` builds a custom DOM event with given `eventName` and `detail` data
+        // and triggers it on element given as `el`.
+        var triggerEvent = function( el, eventName, detail ) {
+            var event = document.createEvent( "CustomEvent" );
+            event.initCustomEvent( eventName, true, true, detail );
+            el.dispatchEvent( event );
+        };
+
+        var lib = {
+            $: $,
+            $$: $$,
+            arrayify: arrayify,
+            byId: byId,
+            getElementFromHash: getElementFromHash,
+            throttle: throttle,
+            toNumber: toNumber,
+            triggerEvent: triggerEvent
+        };
+        roots[ rootId ] = lib;
+        return lib;
+    };
+
+    // Let impress core know about the existence of this library
+    window.impress.addLibraryFactory( { util: libraryFactory } );
+
+} )( document, window );

--- a/src/plugins/navigation/navigation.js
+++ b/src/plugins/navigation/navigation.js
@@ -39,6 +39,7 @@
         // or anything. `impress:init` event data gives you everything you
         // need to control the presentation that was just initialized.
         var api = event.detail.api;
+        var gc = api.lib.gc;
 
         // Supported keys are:
         // [space] - quite common in presentation software to move forward
@@ -87,14 +88,14 @@
         // KEYBOARD NAVIGATION HANDLERS
 
         // Prevent default keydown action when one of supported key is pressed.
-        document.addEventListener( "keydown", function( event ) {
+        gc.addEventListener( document, "keydown", function( event ) {
             if ( isNavigationEvent( event ) ) {
                 event.preventDefault();
             }
         }, false );
 
         // Trigger impress action (next or prev) on keyup.
-        document.addEventListener( "keyup", function( event ) {
+        gc.addEventListener( document, "keyup", function( event ) {
             if ( isNavigationEvent( event ) ) {
                 if ( event.shiftKey ) {
                     switch ( event.keyCode ) {
@@ -123,7 +124,7 @@
         }, false );
 
         // Delegated handler for clicking on the links to presentation steps
-        document.addEventListener( "click", function( event ) {
+        gc.addEventListener( document, "click", function( event ) {
 
             // Event delegation with "bubbling"
             // check if event target (or any of its parents is a link)
@@ -149,7 +150,7 @@
         }, false );
 
         // Delegated handler for clicking on step elements
-        document.addEventListener( "click", function( event ) {
+        gc.addEventListener( document, "click", function( event ) {
             var target = event.target;
 
             // Find closest step element that is not active

--- a/src/plugins/navigation/navigation.js
+++ b/src/plugins/navigation/navigation.js
@@ -25,12 +25,6 @@
 ( function( document ) {
     "use strict";
 
-    var triggerEvent = function( el, eventName, detail ) {
-        var event = document.createEvent( "CustomEvent" );
-        event.initCustomEvent( eventName, true, true, detail );
-        el.dispatchEvent( event );
-    };
-
     // Wait for impress.js to be initialized
     document.addEventListener( "impress:init", function( event ) {
 
@@ -40,6 +34,7 @@
         // need to control the presentation that was just initialized.
         var api = event.detail.api;
         var gc = api.lib.gc;
+        var util = api.lib.util;
 
         // Supported keys are:
         // [space] - quite common in presentation software to move forward
@@ -166,8 +161,9 @@
         }, false );
 
         // Add a line to the help popup
-        triggerEvent( document, "impress:help:add",
-                      { command: "Left &amp; Right", text: "Previous &amp; Next step", row: 1 } );
+        util.triggerEvent( document, "impress:help:add", { command: "Left &amp; Right",
+                                                           text: "Previous &amp; Next step",
+                                                           row: 1 } );
 
     }, false );
 

--- a/src/plugins/resize/resize.js
+++ b/src/plugins/resize/resize.js
@@ -18,25 +18,12 @@
 ( function( document, window ) {
     "use strict";
 
-    // Throttling function calls, by Remy Sharp
-    // http://remysharp.com/2010/07/21/throttling-function-calls/
-    var throttle = function( fn, delay ) {
-        var timer = null;
-        return function() {
-            var context = this, args = arguments;
-            window.clearTimeout( timer );
-            timer = window.setTimeout( function() {
-                fn.apply( context, args );
-            }, delay );
-        };
-    };
-
     // Wait for impress.js to be initialized
     document.addEventListener( "impress:init", function( event ) {
         var api = event.detail.api;
 
         // Rescale presentation when window is resized
-        api.lib.gc.addEventListener( window, "resize", throttle( function() {
+        api.lib.gc.addEventListener( window, "resize", api.lib.util.throttle( function() {
 
             // Force going to active step again, to trigger rescaling
             api.goto( document.querySelector( ".step.active" ), 500 );

--- a/src/plugins/resize/resize.js
+++ b/src/plugins/resize/resize.js
@@ -36,7 +36,7 @@
         var api = event.detail.api;
 
         // Rescale presentation when window is resized
-        window.addEventListener( "resize", throttle( function() {
+        api.lib.gc.addEventListener( window, "resize", throttle( function() {
 
             // Force going to active step again, to trigger rescaling
             api.goto( document.querySelector( ".step.active" ), 500 );


### PR DESCRIPTION
The next step is to move some of the helper functions into src/lib/*.js files and make them available via impress().lib so that plugins can use them as well. In the code already existing here, navigation plugin uses lib.util.triggerEvent().

The other library is gc, a rather complex "garbage collector" mechanism. It is used to keep track of any changes done to the DOM, mostly as an effect of impress().init(), so that they can be undone with impress().tear(). This was a request in the queue, and I ended up needing it myself too. (The other plugins in my own repo all use this library, so therefore it is merged now.)

@bartaz Based on your comment in the previous PR, I will no longer mark you as a reviewer for PRs, but will continue to ping you so you see these. For this one I will in any case now do something else over the weekend, so it will stay here for review for several days.