### PR TITLE
Remove second example for ".tear()"

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -244,16 +244,6 @@ beyond the intended dynamic changes.)
 impress().tear();
 ```
 
-**Example:**
-
-```JavaScript
-var rootElement = document.getElementById( "impress" );
-rootElement.addEventListener( "impress:init", function() {
-  console.log( "Impress init" );
-});
-impress().init();
-```
-
 #### .next()
 
 Navigates to the next step of the presentation using the [`goto()` function](#impressgotostepindexstepelementidstepelement-duration).


### PR DESCRIPTION
This was probably copy/pasted by mistake, see https://github.com/impress/impress.js/pull/625/commits/8c12757b96f699488de7bc1e257f8365dd3471ae#r143401558