### PR TITLE
Merge mobile stuff

### DIFF
--- a/build.js
+++ b/build.js
@@ -10,7 +10,8 @@ buildify()
            'src/plugins/navigation/navigation.js',
            'src/plugins/rel/rel.js',
            'src/plugins/resize/resize.js',
-           'src/plugins/stop/stop.js'])
+           'src/plugins/stop/stop.js',
+           'src/plugins/touch/touch.js'])
   .save('js/impress.js');
 /*
  * Disabled until uglify supports ES6: https://github.com/mishoo/UglifyJS2/issues/448

--- a/build.js
+++ b/build.js
@@ -7,6 +7,7 @@ buildify()
   .concat(['src/lib/util.js'])
   // Plugins from src/plugins
   .concat(['src/plugins/goto/goto.js',
+           'src/plugins/mobile/mobile.js',
            'src/plugins/navigation/navigation.js',
            'src/plugins/rel/rel.js',
            'src/plugins/resize/resize.js',

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 </div>
 <script>
 if ("ontouchstart" in document.documentElement) { 
-    document.querySelector(".hint").innerHTML = "<p>Tap on the left or right to navigate</p>";
+    document.querySelector(".hint").innerHTML = "<p>Swipe left or right to navigate</p>";
 }
 </script>
 

--- a/js/impress.js
+++ b/js/impress.js
@@ -642,6 +642,10 @@
         // transition to happen, this is just to animate the swipe. Once the
         // transition is committed - such as at a touchend event - caller is
         // responsible for also calling prev()/next() as appropriate.
+        //
+        // Note: For now, this function is made available to be used by the swipe plugin (which
+        // is the UI counterpart to this). It is a semi-internal API and intentionally not
+        // documented in DOCUMENTATION.md.
         var swipe = function( pct ) {
             if ( Math.abs( pct ) > 1 ) {
                 return;

--- a/js/impress.js
+++ b/js/impress.js
@@ -1385,6 +1385,96 @@
 
 
 /**
+ * Mobile devices support
+ *
+ * Allow presentation creators to hide all but 3 slides, to save resources, particularly on mobile
+ * devices, using classes body.impress-mobile, .step.prev, .step.active and .step.next.
+ *
+ * Note: This plugin does not take into account possible redirections done with skip, goto etc
+ * plugins. Basically it wouldn't work as intended in such cases, but the active step will at least
+ * be correct.
+ *
+ * Adapted to a plugin from a submission by @Kzeni:
+ * https://github.com/impress/impress.js/issues/333
+ */
+/* global document, navigator */
+( function( document ) {
+    "use strict";
+
+    var getNextStep = function( el ) {
+        var steps = document.querySelectorAll( ".step" );
+        for ( var i = 0; i < steps.length; i++ ) {
+            if ( steps[ i ] === el ) {
+                if ( i + 1 < steps.length ) {
+                    return steps[ i + 1 ];
+                } else {
+                    return steps[ 0 ];
+                }
+            }
+        }
+    };
+    var getPrevStep = function( el ) {
+        var steps = document.querySelectorAll( ".step" );
+        for ( var i = steps.length - 1; i >= 0; i-- ) {
+            if ( steps[ i ] === el ) {
+                if ( i - 1 >= 0 ) {
+                    return steps[ i - 1 ];
+                } else {
+                    return steps[ steps.length - 1 ];
+                }
+            }
+        }
+    };
+
+    // Detect mobile browsers & add CSS class as appropriate.
+    document.addEventListener( "impress:init", function( event ) {
+        var body = document.body;
+        if ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+                 navigator.userAgent
+             ) ) {
+            body.classList.add( "impress-mobile" );
+        }
+
+        // Unset all this on teardown
+        var api = event.detail.api;
+        api.lib.gc.addCallback( function() {
+            document.body.classList.remove( "impress-mobile" );
+            var prev = document.getElementsByClassName( "prev" )[ 0 ];
+            var next = document.getElementsByClassName( "next" )[ 0 ];
+            if ( typeof prev !== "undefined" ) {
+                prev.classList.remove( "prev" );
+            }
+            if ( typeof next !== "undefined" ) {
+                next.classList.remove( "next" );
+            }
+        } );
+    } );
+
+    // Add prev and next classes to the siblings of the newly entered active step element
+    // Remove prev and next classes from their current step elements
+    // Note: As an exception we break namespacing rules, as these are useful general purpose
+    // classes. (Naming rules would require us to use css classes mobile-next and mobile-prev,
+    // based on plugin name.)
+    document.addEventListener( "impress:stepenter", function( event ) {
+	      var oldprev = document.getElementsByClassName( "prev" )[ 0 ];
+	      var oldnext = document.getElementsByClassName( "next" )[ 0 ];
+
+	      var prev = getPrevStep( event.target );
+	      prev.classList.add( "prev" );
+	      var next = getNextStep( event.target );
+	      next.classList.add( "next" );
+
+	      if ( typeof oldprev !== "undefined" ) {
+		      oldprev.classList.remove( "prev" );
+              }
+	      if ( typeof oldnext !== "undefined" ) {
+		      oldnext.classList.remove( "next" );
+              }
+    } );
+} )( document );
+
+
+/**
  * Navigation events plugin
  *
  * As you can see this part is separate from the impress.js core code.

--- a/js/impress.js
+++ b/js/impress.js
@@ -54,6 +54,28 @@
 
     } )();
 
+    var validateOrder = function( order, fallback ) {
+        var validChars = "xyz";
+        var returnStr = "";
+        if ( typeof order === "string" ) {
+            for ( var i in order.split( "" ) ) {
+                if ( validChars.indexOf( order[ i ] >= 0 ) ) {
+                    returnStr += order[ i ];
+
+                    // Each of x,y,z can be used only once.
+                    validChars = validChars.split( order[ i ] ).join( "" );
+                }
+            }
+        }
+        if ( returnStr ) {
+            return returnStr;
+        } else if ( fallback !== undefined ) {
+            return fallback;
+        } else {
+            return "xyz";
+        }
+    };
+
     // `css` function applies the styles given in `props` object to the element
     // given as `el`. It runs all property names through `pfx` function to make
     // sure proper prefixed version of the property is used.
@@ -79,11 +101,17 @@
     // By default the rotations are in X Y Z order that can be reverted by passing `true`
     // as second parameter.
     var rotate = function( r, revert ) {
-        var rX = " rotateX(" + r.x + "deg) ",
-            rY = " rotateY(" + r.y + "deg) ",
-            rZ = " rotateZ(" + r.z + "deg) ";
+        var order = r.order ? r.order : "xyz";
+        var css = "";
+        var axes = order.split( "" );
+        if ( revert ) {
+            axes = axes.reverse();
+        }
 
-        return revert ? rZ + rY + rX : rX + rY + rZ;
+        for ( var i = 0; i < axes.length; i++ ) {
+            css += " rotate" + axes[ i ].toUpperCase() + "(" + r[ axes[ i ] ] + "deg)";
+        }
+        return css;
     };
 
     // `scale` builds a scale transform string for given data.
@@ -259,7 +287,8 @@
                     rotate: {
                         x: lib.util.toNumber( data.rotateX ),
                         y: lib.util.toNumber( data.rotateY ),
-                        z: lib.util.toNumber( data.rotateZ || data.rotate )
+                        z: lib.util.toNumber( data.rotateZ || data.rotate ),
+                        order: validateOrder( data.rotateOrder )
                     },
                     scale: lib.util.toNumber( data.scale, 1 ),
                     transitionDuration: lib.util.toNumber(
@@ -359,7 +388,7 @@
             // Set a default initial state of the canvas
             currentState = {
                 translate: { x: 0, y: 0, z: 0 },
-                rotate:    { x: 0, y: 0, z: 0 },
+                rotate:    { x: 0, y: 0, z: 0, order: "xyz" },
                 scale:     1
             };
 
@@ -459,7 +488,8 @@
                 rotate: {
                     x: -step.rotate.x,
                     y: -step.rotate.y,
-                    z: -step.rotate.z
+                    z: -step.rotate.z,
+                    order: step.rotate.order
                 },
                 translate: {
                     x: -step.translate.x,

--- a/js/impress.js
+++ b/js/impress.js
@@ -225,11 +225,15 @@
         // `onStepEnter` is called whenever the step element is entered
         // but the event is triggered only if the step is different than
         // last entered step.
+        // We sometimes call `goto`, and therefore `onStepEnter`, just to redraw a step, such as
+        // after screen resize. In this case - more precisely, in any case - we trigger a
+        // `impress:steprefresh` event.
         var onStepEnter = function( step ) {
             if ( lastEntered !== step ) {
                 lib.util.triggerEvent( step, "impress:stepenter" );
                 lastEntered = step;
             }
+            lib.util.triggerEvent( step, "impress:steprefresh" );
         };
 
         // `onStepLeave` is called whenever the currentStep element is left

--- a/js/impress.js
+++ b/js/impress.js
@@ -262,6 +262,9 @@
                         z: lib.util.toNumber( data.rotateZ || data.rotate )
                     },
                     scale: lib.util.toNumber( data.scale, 1 ),
+                    transitionDuration: lib.util.toNumber(
+                        data.transitionDuration, config.transitionDuration
+                    ),
                     el: el
                 };
 
@@ -311,7 +314,7 @@
                 minScale: lib.util.toNumber( rootData.minScale, defaults.minScale ),
                 perspective: lib.util.toNumber( rootData.perspective, defaults.perspective ),
                 transitionDuration: lib.util.toNumber(
-                  rootData.transitionDuration, defaults.transitionDuration
+                    rootData.transitionDuration, defaults.transitionDuration
                 )
             };
 
@@ -416,6 +419,7 @@
             window.scrollTo( 0, 0 );
 
             var step = stepsData[ "impress-" + el.id ];
+            duration = ( duration !== undefined ? duration : step.transitionDuration );
 
             // If we are in fact moving to another step, start with executing the registered
             // preStepLeave plugins.

--- a/src/impress.js
+++ b/src/impress.js
@@ -642,6 +642,10 @@
         // transition to happen, this is just to animate the swipe. Once the
         // transition is committed - such as at a touchend event - caller is
         // responsible for also calling prev()/next() as appropriate.
+        //
+        // Note: For now, this function is made available to be used by the swipe plugin (which
+        // is the UI counterpart to this). It is a semi-internal API and intentionally not
+        // documented in DOCUMENTATION.md.
         var swipe = function( pct ) {
             if ( Math.abs( pct ) > 1 ) {
                 return;

--- a/src/impress.js
+++ b/src/impress.js
@@ -54,6 +54,28 @@
 
     } )();
 
+    var validateOrder = function( order, fallback ) {
+        var validChars = "xyz";
+        var returnStr = "";
+        if ( typeof order === "string" ) {
+            for ( var i in order.split( "" ) ) {
+                if ( validChars.indexOf( order[ i ] >= 0 ) ) {
+                    returnStr += order[ i ];
+
+                    // Each of x,y,z can be used only once.
+                    validChars = validChars.split( order[ i ] ).join( "" );
+                }
+            }
+        }
+        if ( returnStr ) {
+            return returnStr;
+        } else if ( fallback !== undefined ) {
+            return fallback;
+        } else {
+            return "xyz";
+        }
+    };
+
     // `css` function applies the styles given in `props` object to the element
     // given as `el`. It runs all property names through `pfx` function to make
     // sure proper prefixed version of the property is used.
@@ -79,11 +101,17 @@
     // By default the rotations are in X Y Z order that can be reverted by passing `true`
     // as second parameter.
     var rotate = function( r, revert ) {
-        var rX = " rotateX(" + r.x + "deg) ",
-            rY = " rotateY(" + r.y + "deg) ",
-            rZ = " rotateZ(" + r.z + "deg) ";
+        var order = r.order ? r.order : "xyz";
+        var css = "";
+        var axes = order.split( "" );
+        if ( revert ) {
+            axes = axes.reverse();
+        }
 
-        return revert ? rZ + rY + rX : rX + rY + rZ;
+        for ( var i = 0; i < axes.length; i++ ) {
+            css += " rotate" + axes[ i ].toUpperCase() + "(" + r[ axes[ i ] ] + "deg)";
+        }
+        return css;
     };
 
     // `scale` builds a scale transform string for given data.
@@ -259,7 +287,8 @@
                     rotate: {
                         x: lib.util.toNumber( data.rotateX ),
                         y: lib.util.toNumber( data.rotateY ),
-                        z: lib.util.toNumber( data.rotateZ || data.rotate )
+                        z: lib.util.toNumber( data.rotateZ || data.rotate ),
+                        order: validateOrder( data.rotateOrder )
                     },
                     scale: lib.util.toNumber( data.scale, 1 ),
                     transitionDuration: lib.util.toNumber(
@@ -359,7 +388,7 @@
             // Set a default initial state of the canvas
             currentState = {
                 translate: { x: 0, y: 0, z: 0 },
-                rotate:    { x: 0, y: 0, z: 0 },
+                rotate:    { x: 0, y: 0, z: 0, order: "xyz" },
                 scale:     1
             };
 
@@ -459,7 +488,8 @@
                 rotate: {
                     x: -step.rotate.x,
                     y: -step.rotate.y,
-                    z: -step.rotate.z
+                    z: -step.rotate.z,
+                    order: step.rotate.order
                 },
                 translate: {
                     x: -step.translate.x,

--- a/src/impress.js
+++ b/src/impress.js
@@ -111,21 +111,14 @@
 
     // CHECK SUPPORT
     var body = document.body;
-
-    var ua = navigator.userAgent.toLowerCase();
     var impressSupported =
 
                           // Browser should support CSS 3D transtorms
                            ( pfx( "perspective" ) !== null ) &&
 
-                          // Browser should support `classList` and `dataset` APIs
+                          // And `classList` and `dataset` APIs
                            ( body.classList ) &&
-                           ( body.dataset ) &&
-
-                          // But some mobile devices need to be blacklisted,
-                          // because their CSS 3D support or hardware is not
-                          // good enough to run impress.js properly, sorry...
-                           ( ua.search( /(iphone)|(ipod)|(android)/ ) === -1 );
+                           ( body.dataset );
 
     if ( !impressSupported ) {
 
@@ -175,6 +168,7 @@
                 goto: empty,
                 prev: empty,
                 next: empty,
+                swipe: empty,
                 tear: empty,
                 lib: {}
             };
@@ -583,6 +577,110 @@
             return goto( next, undefined, "next", origEvent );
         };
 
+        // Swipe for touch devices by @and3rson.
+        // Below we extend the api to control the animation between the currently
+        // active step and a presumed next/prev step. See touch plugin for
+        // an example of using this api.
+
+        // Helper function
+        var interpolate = function( a, b, k ) {
+            return a + ( b - a ) * k;
+        };
+
+        // Animate a swipe.
+        //
+        // Pct is a value between -1.0 and +1.0, designating the current length
+        // of the swipe.
+        //
+        // If pct is negative, swipe towards the next() step, if positive,
+        // towards the prev() step.
+        //
+        // Note that pre-stepleave plugins such as goto can mess with what is a
+        // next() and prev() step, so we need to trigger the pre-stepleave event
+        // here, even if a swipe doesn't guarantee that the transition will
+        // actually happen.
+        //
+        // Calling swipe(), with any value of pct, won't in itself cause a
+        // transition to happen, this is just to animate the swipe. Once the
+        // transition is committed - such as at a touchend event - caller is
+        // responsible for also calling prev()/next() as appropriate.
+        var swipe = function( pct ) {
+            if ( Math.abs( pct ) > 1 ) {
+                return;
+            }
+
+            // Prepare & execute the preStepLeave event
+            var event = { target: activeStep, detail: {} };
+            event.detail.swipe = pct;
+
+            // Will be ignored within swipe animation, but just in case a plugin wants to read this,
+            // humor them
+            event.detail.transitionDuration = config.transitionDuration;
+            var idx; // Needed by jshint
+            if ( pct < 0 ) {
+                idx = steps.indexOf( activeStep ) + 1;
+                event.detail.next = idx < steps.length ? steps[ idx ] : steps[ 0 ];
+                event.detail.reason = "next";
+            } else if ( pct > 0 ) {
+                idx = steps.indexOf( activeStep ) - 1;
+                event.detail.next = idx >= 0 ? steps[ idx ] : steps[ steps.length - 1 ];
+                event.detail.reason = "prev";
+            } else {
+
+                // No move
+                return;
+            }
+            if ( execPreStepLeavePlugins( event ) === false ) {
+
+                // If a preStepLeave plugin wants to abort the transition, don't animate a swipe
+                // For stop, this is probably ok. For substep, the plugin it self might want to do
+                // some animation, but that's not the current implementation.
+                return false;
+            }
+            var nextElement = event.detail.next;
+
+            var nextStep = stepsData[ "impress-" + nextElement.id ];
+
+            // If the same step is re-selected, force computing window scaling,
+            var nextScale = nextStep.scale * windowScale;
+            var k = Math.abs( pct );
+
+            var interpolatedStep = {
+                translate: {
+                    x: interpolate( currentState.translate.x, -nextStep.translate.x, k ),
+                    y: interpolate( currentState.translate.y, -nextStep.translate.y, k ),
+                    z: interpolate( currentState.translate.z, -nextStep.translate.z, k )
+                },
+                rotate: {
+                    x: interpolate( currentState.rotate.x, -nextStep.rotate.x, k ),
+                    y: interpolate( currentState.rotate.y, -nextStep.rotate.y, k ),
+                    z: interpolate( currentState.rotate.z, -nextStep.rotate.z, k ),
+
+                    // Unfortunately there's a discontinuity if rotation order changes. Nothing I
+                    // can do about it?
+                    order: k < 0.7 ? currentState.rotate.order : nextStep.rotate.order
+                },
+                scale: interpolate( currentState.scale, nextScale, k )
+            };
+
+            css( root, {
+
+                // To keep the perspective look similar for different scales
+                // we need to 'scale' the perspective, too
+                perspective: config.perspective / interpolatedStep.scale + "px",
+                transform: scale( interpolatedStep.scale ),
+                transitionDuration: "0ms",
+                transitionDelay: "0ms"
+            } );
+
+            css( canvas, {
+                transform: rotate( interpolatedStep.rotate, true ) +
+                           translate( interpolatedStep.translate ),
+                transitionDuration: "0ms",
+                transitionDelay: "0ms"
+            } );
+        };
+
         // Teardown impress
         // Resets the DOM to the state it was before impress().init() was called.
         // (If you called impress(rootId).init() for multiple different rootId's, then you must
@@ -666,6 +764,7 @@
             goto: goto,
             next: next,
             prev: prev,
+            swipe: swipe,
             tear: tear,
             lib: lib
         } );

--- a/src/impress.js
+++ b/src/impress.js
@@ -225,11 +225,15 @@
         // `onStepEnter` is called whenever the step element is entered
         // but the event is triggered only if the step is different than
         // last entered step.
+        // We sometimes call `goto`, and therefore `onStepEnter`, just to redraw a step, such as
+        // after screen resize. In this case - more precisely, in any case - we trigger a
+        // `impress:steprefresh` event.
         var onStepEnter = function( step ) {
             if ( lastEntered !== step ) {
                 lib.util.triggerEvent( step, "impress:stepenter" );
                 lastEntered = step;
             }
+            lib.util.triggerEvent( step, "impress:steprefresh" );
         };
 
         // `onStepLeave` is called whenever the currentStep element is left

--- a/src/impress.js
+++ b/src/impress.js
@@ -262,6 +262,9 @@
                         z: lib.util.toNumber( data.rotateZ || data.rotate )
                     },
                     scale: lib.util.toNumber( data.scale, 1 ),
+                    transitionDuration: lib.util.toNumber(
+                        data.transitionDuration, config.transitionDuration
+                    ),
                     el: el
                 };
 
@@ -311,7 +314,7 @@
                 minScale: lib.util.toNumber( rootData.minScale, defaults.minScale ),
                 perspective: lib.util.toNumber( rootData.perspective, defaults.perspective ),
                 transitionDuration: lib.util.toNumber(
-                  rootData.transitionDuration, defaults.transitionDuration
+                    rootData.transitionDuration, defaults.transitionDuration
                 )
             };
 
@@ -416,6 +419,7 @@
             window.scrollTo( 0, 0 );
 
             var step = stepsData[ "impress-" + el.id ];
+            duration = ( duration !== undefined ? duration : step.transitionDuration );
 
             // If we are in fact moving to another step, start with executing the registered
             // preStepLeave plugins.

--- a/src/plugins/mobile/README.md
+++ b/src/plugins/mobile/README.md
@@ -1,0 +1,38 @@
+Mobile devices support
+======================
+
+Presentations with a lot of 3D effects and graphics can consume a lot of resources, especially on mobile devices.
+This plugin provides some CSS classes that can be used to hide most of the slides, only showing the current, previous
+and next slide.
+
+In particular, this plugin adds:
+
+`body.impress-mobile` class, if it detects running on a mobile OS.
+
+`div.prev` and `div.prev` to the adjacent steps to the current one. Note that the current slide is already identified
+by `present` and `active` CSS classes.
+
+Example CSS
+-----------
+
+        body.impress-mobile .step { 
+            display:none;
+        }
+        body.impress-mobile .step.active,
+        body.impress-mobile .step.present,
+        body.impress-mobile .step.next,
+        body.impress-mobile .step.prev { 
+            display:block; 
+        }
+
+Note
+----
+
+This plugin does not take into account redirects that could happen with skip, goto and other plugins. The active
+step will of course always be correct, but "non-linear" transitions to anything else than the actual previous and next
+steps will probably not look correct.
+
+Author
+------
+
+Kurt Zenisek (@KZeni)

--- a/src/plugins/mobile/mobile.js
+++ b/src/plugins/mobile/mobile.js
@@ -1,0 +1,89 @@
+/**
+ * Mobile devices support
+ *
+ * Allow presentation creators to hide all but 3 slides, to save resources, particularly on mobile
+ * devices, using classes body.impress-mobile, .step.prev, .step.active and .step.next.
+ *
+ * Note: This plugin does not take into account possible redirections done with skip, goto etc
+ * plugins. Basically it wouldn't work as intended in such cases, but the active step will at least
+ * be correct.
+ *
+ * Adapted to a plugin from a submission by @Kzeni:
+ * https://github.com/impress/impress.js/issues/333
+ */
+/* global document, navigator */
+( function( document ) {
+    "use strict";
+
+    var getNextStep = function( el ) {
+        var steps = document.querySelectorAll( ".step" );
+        for ( var i = 0; i < steps.length; i++ ) {
+            if ( steps[ i ] === el ) {
+                if ( i + 1 < steps.length ) {
+                    return steps[ i + 1 ];
+                } else {
+                    return steps[ 0 ];
+                }
+            }
+        }
+    };
+    var getPrevStep = function( el ) {
+        var steps = document.querySelectorAll( ".step" );
+        for ( var i = steps.length - 1; i >= 0; i-- ) {
+            if ( steps[ i ] === el ) {
+                if ( i - 1 >= 0 ) {
+                    return steps[ i - 1 ];
+                } else {
+                    return steps[ steps.length - 1 ];
+                }
+            }
+        }
+    };
+
+    // Detect mobile browsers & add CSS class as appropriate.
+    document.addEventListener( "impress:init", function( event ) {
+        var body = document.body;
+        if ( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+                 navigator.userAgent
+             ) ) {
+            body.classList.add( "impress-mobile" );
+        }
+
+        // Unset all this on teardown
+        var api = event.detail.api;
+        api.lib.gc.addCallback( function() {
+            document.body.classList.remove( "impress-mobile" );
+            var prev = document.getElementsByClassName( "prev" )[ 0 ];
+            var next = document.getElementsByClassName( "next" )[ 0 ];
+            if ( typeof prev !== "undefined" ) {
+                prev.classList.remove( "prev" );
+            }
+            if ( typeof next !== "undefined" ) {
+                next.classList.remove( "next" );
+            }
+        } );
+    } );
+
+    // Add prev and next classes to the siblings of the newly entered active step element
+    // Remove prev and next classes from their current step elements
+    // Note: As an exception we break namespacing rules, as these are useful general purpose
+    // classes. (Naming rules would require us to use css classes mobile-next and mobile-prev,
+    // based on plugin name.)
+    document.addEventListener( "impress:stepenter", function( event ) {
+	      var oldprev = document.getElementsByClassName( "prev" )[ 0 ];
+	      var oldnext = document.getElementsByClassName( "next" )[ 0 ];
+
+	      var prev = getPrevStep( event.target );
+	      prev.classList.add( "prev" );
+	      var next = getNextStep( event.target );
+	      next.classList.add( "next" );
+
+	      if ( typeof oldprev !== "undefined" ) {
+		      oldprev.classList.remove( "prev" );
+              }
+	      if ( typeof oldnext !== "undefined" ) {
+		      oldnext.classList.remove( "next" );
+              }
+    } );
+} )( document );
+

--- a/src/plugins/touch/touch.js
+++ b/src/plugins/touch/touch.js
@@ -1,0 +1,68 @@
+/**
+ * Support for swipe and tap on touch devices
+ *
+ * This plugin implements navigation for plugin devices, via swiping left/right,
+ * or tapping on the left/right edges of the screen.
+ *
+ *
+ *
+ * Copyright 2015: Andrew Dunai (@and3rson)
+ * Modified to a plugin, 2016: Henrik Ingo (@henrikingo)
+ *
+ * MIT License
+ */
+/* global document, window */
+( function( document, window ) {
+    "use strict";
+
+    // Touch handler to detect swiping left and right based on window size.
+    // If the difference in X change is bigger than 1/20 of the screen width,
+    // we simply call an appropriate API function to complete the transition.
+    var startX = 0;
+    var lastX = 0;
+    var lastDX = 0;
+    var threshold = window.innerWidth / 20;
+
+    document.addEventListener( "touchstart", function( event ) {
+        lastX = startX = event.touches[ 0 ].clientX;
+    } );
+
+    document.addEventListener( "touchmove", function( event ) {
+         var x = event.touches[ 0 ].clientX;
+         var diff = x - startX;
+
+         // To be used in touchend
+         lastDX = lastX - x;
+         lastX = x;
+
+         window.impress().swipe( diff / window.innerWidth );
+     } );
+
+     document.addEventListener( "touchend", function() {
+         var totalDiff = lastX - startX;
+         if ( Math.abs( totalDiff ) > window.innerWidth / 5 && ( totalDiff * lastDX ) <= 0 ) {
+             if ( totalDiff > window.innerWidth / 5 && lastDX <= 0 ) {
+                 window.impress().prev();
+             } else if ( totalDiff < -window.innerWidth / 5 && lastDX >= 0 ) {
+                 window.impress().next();
+             }
+         } else if ( Math.abs( lastDX ) > threshold ) {
+             if ( lastDX < -threshold ) {
+                 window.impress().prev();
+             } else if ( lastDX > threshold ) {
+                 window.impress().next();
+             }
+         } else {
+
+             // No movement - move (back) to the current slide
+             window.impress().goto( document.querySelector( "#impress .step.active" ) );
+         }
+     } );
+
+     document.addEventListener( "touchcancel", function() {
+
+             // Move (back) to the current slide
+             window.impress().goto( document.querySelector( "#impress .step.active" ) );
+     } );
+
+} )( document, window );


### PR DESCRIPTION
@bartaz : From now on this is basically just more plugins and more stuff. 

This first bucket contains a couple plugins that were hanging around in the PR queue. I have adapted them to the new plugin framework while still putting original author as author. Related to these plugins, the check that prevents from running on mobile phones is removed from core. (I'm aware you've been reluctant to do that, but this is a very common request from community. The mobile plugin attempts to help making presentations consume less memory when targeting mobiles.)

The swipe feature requires working with data structures in core. I've separated out that part, and it adds a new API function: impress().swipe(). The plugin part contains the UI facing part.

In the same PR some unrelated commits to core impress.js. After this, impress.js file is now identical to what I have in my fork.