### PR TITLE
Moved CSS class changes on entering and leaving steps

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -276,6 +276,9 @@
         // last entered step.
         var onStepEnter = function( step ) {
             if ( lastEntered !== step ) {
+                step.classList.remove( "past" );
+                step.classList.remove( "future" );
+                step.classList.add( "present" );
                 triggerEvent( step, "impress:stepenter" );
                 lastEntered = step;
             }
@@ -286,6 +289,8 @@
         // last entered step.
         var onStepLeave = function( step ) {
             if ( lastEntered === step ) {
+                step.classList.remove( "present" );
+                step.classList.add( "past" );
                 triggerEvent( step, "impress:stepleave" );
                 lastEntered = null;
             }
@@ -603,18 +608,6 @@
             steps.forEach( function( step ) {
                 step.classList.add( "future" );
             } );
-
-            root.addEventListener( "impress:stepenter", function( event ) {
-                event.target.classList.remove( "past" );
-                event.target.classList.remove( "future" );
-                event.target.classList.add( "present" );
-            }, false );
-
-            root.addEventListener( "impress:stepleave", function( event ) {
-                event.target.classList.remove( "present" );
-                event.target.classList.add( "past" );
-            }, false );
-
         }, false );
 
         // Adding hash change support.


### PR DESCRIPTION
Moved CSS class changes on entering and leaving steps into onStepEnter and onStepLeave methods. This allows event listeners for `impress:stepenter` and `impress:stepleave` events to reliably select the correct steps by class.

**Make sure these boxes are checked before submitting your Pull Request, thank you!**

- [x] I have read and complied with the [Pull Request Contributing Guidelines](https://github.com/impress/impress.js/blob/master/CONTRIBUTING.md#pull-requests).
- [x] I checked if an [an issue](https://github.com/impress/impress.js/issues) is necessary for my Pull Request and made sure it exists.
- [x] I have created a [topic branch](https://github.com/dchelimsky/rspec/wiki/Topic-Branches).
- [x] I have used the [Search Tool](https://github.com/impress/impress.js/search?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen&type=Issues) to make sure there are no open Pull Requests fixing the same thing.