### PR TITLE
Fixed the link to "extra addons" in the plugins README

### DIFF
--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -21,10 +21,11 @@ Extra addons
 ------------
 
 Yet more features are available in presentations that enable 
-[extra addons](https://github.com/impress/impress-extras). Extra addons are 3rd party plugins integrated
-into impress.js to provide convenient and standardized access to them. However,
-they are not activated by default, rather must be included with a `<script>`
-tag.
+[extra addons](https://github.com/impress/impress-extras). Extra addons are 3rd party plugins 
+that are not part of impress.js, but that we have nevertheless collected together into the 
+impress-extras repo to provide convenient and standardized access to them. To include 
+the extra addons when checking out impress.js, use git clone --recursive. Even then, they 
+are not activated by default in a presentation, rather each must be included with their own `<script>` tag.
 
 Note: The enabled extra addons are automatically initialized by the *extras*
 plugin.

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -21,7 +21,7 @@ Extra addons
 ------------
 
 Yet more features are available in presentations that enable 
-[extra addons](../../extras/). Extra addons are 3rd party plugins integrated
+[extra addons](https://github.com/impress/impress-extras). Extra addons are 3rd party plugins integrated
 into impress.js to provide convenient and standardized access to them. However,
 they are not activated by default, rather must be included with a `<script>`
 tag.


### PR DESCRIPTION
Fix for issue [#646](https://github.com/impress/impress.js/issues/646) changed the link in the README to point to https://github.com/impress/impress-extras