### PR TITLE
add CNAME for impress.js.org (Resolves issue #655)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+impress.js.org


### PR DESCRIPTION
After @henrikingo has given approval to pursue setting up a custom sub-domain impress.js.org with [dns.js.org](dns.js.org) in issue #655, this creates the [CNAME file](https://help.github.com/articles/setting-up-a-custom-subdomain/) so that the custom domain can be set.