### PR TITLE
Fix some touch bugs on mobile phones.

### DIFF
--- a/src/plugins/touch/touch.js
+++ b/src/plugins/touch/touch.js
@@ -25,6 +25,7 @@
 
     document.addEventListener( "touchstart", function( event ) {
         lastX = startX = event.touches[ 0 ].clientX;
+        event.preventDefault();
     } );
 
     document.addEventListener( "touchmove", function( event ) {
@@ -36,6 +37,7 @@
          lastX = x;
 
          window.impress().swipe( diff / window.innerWidth );
+         event.preventDefault();
      } );
 
      document.addEventListener( "touchend", function() {


### PR DESCRIPTION
Call event.preventDefault() to prevent scrolling on WebKits and to prevent strange "touchcancel" events on Android WebViews.