### PR TITLE
Bugfix: Scaling bug on swipe, when window scale is not 1

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -705,7 +705,7 @@
                     // can do about it?
                     order: k < 0.7 ? currentState.rotate.order : nextStep.rotate.order
                 },
-                scale: interpolate( currentState.scale, nextScale, k )
+                scale: interpolate( currentState.scale * windowScale, nextScale, k )
             };
 
             css( root, {

--- a/src/impress.js
+++ b/src/impress.js
@@ -703,7 +703,7 @@
                     // can do about it?
                     order: k < 0.7 ? currentState.rotate.order : nextStep.rotate.order
                 },
-                scale: interpolate( currentState.scale, nextScale, k )
+                scale: interpolate( currentState.scale * windowScale, nextScale, k )
             };
 
             css( root, {


### PR DESCRIPTION
When swiping to the next page on mobile, the scaling on the current page is massive and interpolates to the correct scale of the next page.
In the code the current page's scale is not corrected for the window's scale, which is corrected in this MR.

For reproducability, visit the demo (https://impress.js.org/) on mobile and swipe to the next page.
Issue that relates to the problem:  https://github.com/impress/impress.js/issues/690