### PR TITLE
Fix typo in doc: autostart -> autoplay

### DIFF
--- a/src/plugins/media/media.js
+++ b/src/plugins/media/media.js
@@ -26,22 +26,22 @@
  *    overwritten for individual steps and media.
  *
  *    Examples:
- *    - data-media-autostart="true" data-media-autostop="true": start media on enter, stop on
+ *    - data-media-autoplay="true" data-media-autostop="true": start media on enter, stop on
  *      leave, restart from beginning when re-entering the step.
  *
- *    - data-media-autostart="true" data-media-autopause="true": start media on enter, pause on
+ *    - data-media-autoplay="true" data-media-autopause="true": start media on enter, pause on
  *      leave, resume on re-enter
  *
- *    - data-media-autostart="true" data-media-autostop="true" data-media-autopause="true": start
+ *    - data-media-autoplay="true" data-media-autostop="true" data-media-autopause="true": start
  *      media on enter, stop on leave (stop overwrites pause).
  *
- *    - data-media-autostart="true" data-media-autopause="false": let media start automatically
+ *    - data-media-autoplay="true" data-media-autopause="false": let media start automatically
  *      when entering a step and let it play when leaving the step.
  *
- *    - <div id="impress" data-media-autostart="true"> ... <div class="step"
- *      data-media-autostart="false">
+ *    - <div id="impress" data-media-autoplay="true"> ... <div class="step"
+ *      data-media-autoplay="false">
  *      All media is startet automatically on all steps except the one that has the
- *      data-media-autostart="false" attribute.
+ *      data-media-autoplay="false" attribute.
  *
  *  - Pro tip: Use <audio onended="impress().next()"> or <video onended="impress().next()"> to
  *    proceed to the next step automatically, when the end of the media is reached.


### PR DESCRIPTION
The documentation of the media plugin uses `data-media-autostart` instead of `data-media-autoplay`.