### PR TITLE
Add autoplay URL parameter trigger.

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -1207,6 +1207,17 @@
             return byId( window.location.hash.replace( /^#\/?/, "" ) );
         };
 
+        // `getUrlParamValue` return a given URL parameter value if it exists
+        // `undefined` if it doesn't exist
+        var getUrlParamValue = function( parameter ) {
+            var chunk = window.location.search.split( parameter + "=" )[ 1 ];
+            var value = chunk && chunk.split( "&" )[ 0 ];
+
+            if ( value !== "" ) {
+                return value;
+            }
+        };
+
         // Throttling function calls, by Remy Sharp
         // http://remysharp.com/2010/07/21/throttling-function-calls/
         var throttle = function( fn, delay ) {
@@ -1243,7 +1254,8 @@
             getElementFromHash: getElementFromHash,
             throttle: throttle,
             toNumber: toNumber,
-            triggerEvent: triggerEvent
+            triggerEvent: triggerEvent,
+            getUrlParamValue: getUrlParamValue
         };
         roots[ rootId ] = lib;
         return lib;
@@ -1287,9 +1299,10 @@
         // Element attributes starting with "data-", become available under
         // element.dataset. In addition hyphenized words become camelCased.
         var data = root.dataset;
+        var autoplay = util.getUrlParamValue( "impress-autoplay" ) || data.autoplay;
 
-        if ( data.autoplay ) {
-            autoplayDefault = util.toNumber( data.autoplay, 0 );
+        if ( autoplay ) {
+            autoplayDefault = util.toNumber( autoplay, 0 );
         }
 
         var toolbar = document.querySelector( "#impress-toolbar" );

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -49,6 +49,17 @@
             return byId( window.location.hash.replace( /^#\/?/, "" ) );
         };
 
+        // `getUrlParamValue` return a given URL parameter value if it exists
+        // `undefined` if it doesn't exist
+        var getUrlParamValue = function( parameter ) {
+            var chunk = window.location.search.split( parameter + "=" )[ 1 ];
+            var value = chunk && chunk.split( "&" )[ 0 ];
+
+            if ( value !== "" ) {
+                return value;
+            }
+        };
+
         // Throttling function calls, by Remy Sharp
         // http://remysharp.com/2010/07/21/throttling-function-calls/
         var throttle = function( fn, delay ) {
@@ -85,7 +96,8 @@
             getElementFromHash: getElementFromHash,
             throttle: throttle,
             toNumber: toNumber,
-            triggerEvent: triggerEvent
+            triggerEvent: triggerEvent,
+            getUrlParamValue: getUrlParamValue
         };
         roots[ rootId ] = lib;
         return lib;

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -14,7 +14,8 @@ rather require the user to invoke them somehow. For example:
 * The *navigation* plugin waits for the user to press some keys, arrows, page
   down, page up, space or tab.
 * The *autoplay* plugin looks for the HTML attribute `data-autoplay` to see
-  whether it should do its thing.
+  whether it should do its thing. It can also be triggered with a URL GET parameter
+  `?impress-autoplay=5` *5 is the waiting duration*. 
 * The *toolbar* plugin looks for a `<div>` element to become visible.
 
 Extra addons

--- a/src/plugins/autoplay/autoplay.js
+++ b/src/plugins/autoplay/autoplay.js
@@ -31,9 +31,10 @@
         // Element attributes starting with "data-", become available under
         // element.dataset. In addition hyphenized words become camelCased.
         var data = root.dataset;
+        var autoplay = util.getUrlParamValue( "impress-autoplay" ) || data.autoplay;
 
-        if ( data.autoplay ) {
-            autoplayDefault = util.toNumber( data.autoplay, 0 );
+        if ( autoplay ) {
+            autoplayDefault = util.toNumber( autoplay, 0 );
         }
 
         var toolbar = document.querySelector( "#impress-toolbar" );


### PR DESCRIPTION
Adding autoplay URL GET parameter trigger. it will take the duration as value `?impress-autoplay=${duration}`.

- **NOTE**: If the Parameter is passed, it will take precedence over the HTML data parameter.
 
- **Demo**:
![impress_autoplay](https://user-images.githubusercontent.com/26286907/77677942-803b2900-6fa1-11ea-939c-1651f76d16c3.gif)


Resolves #720