### PR TITLE
byId support non ascii characters to support non ascii id for steps

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -1204,7 +1204,8 @@
 
             // Get id from url # by removing `#` or `#/` from the beginning,
             // so both "fallback" `#slide-id` and "enhanced" `#/slide-id` will work
-            return byId( window.location.hash.replace( /^#\/?/, "" ) );
+            var encoded = window.location.hash.replace( /^#\/?/, "" );
+            return byId( decodeURIComponent( encoded ) );
         };
 
         // `getUrlParamValue` return a given URL parameter value if it exists

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -46,7 +46,8 @@
 
             // Get id from url # by removing `#` or `#/` from the beginning,
             // so both "fallback" `#slide-id` and "enhanced" `#/slide-id` will work
-            return byId( window.location.hash.replace( /^#\/?/, "" ) );
+            var encoded = window.location.hash.replace( /^#\/?/, "" );
+            return byId( decodeURIComponent( encoded ) );
         };
 
         // `getUrlParamValue` return a given URL parameter value if it exists


### PR DESCRIPTION
``impress.js`` currently gets step id from page hash and pass it to ``byId()`` to jump to specified step.
``byId()`` uses ``document.getElementById( id )``, it works fine with ascii characters.  But for non-ascii ids, it may be url encoded, so ``byId()`` failed to get element by those ids.
This PR uses ``decodeURIComponent( id )`` to decode step id before passing to ``document.getElementById( )``, so it handles unicode step ids too.


