### PR TITLE
Fix slides continuing during blackout

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -1981,7 +1981,6 @@
         root = event.target;
         canvas = root.firstElementChild;
         var gc = api.lib.gc;
-        var util = api.lib.util;
 
         gc.addEventListener( document, "keydown", function( event ) {
 

--- a/src/plugins/blackout/blackout.js
+++ b/src/plugins/blackout/blackout.js
@@ -88,7 +88,6 @@
         root = event.target;
         canvas = root.firstElementChild;
         var gc = api.lib.gc;
-        var util = api.lib.util;
 
         gc.addEventListener( document, "keydown", function( event ) {
 


### PR DESCRIPTION
When triggering blackout the content would be hidden. Autoplay, however, would not be paused because the util variable was null. This happened because immediately after assigning to the correct util variable, a new one was defined using the var keyword. I don't know a lot about javascript, but, as I understand it,this somehow overwrote the original variable, as its value was null afterwards. This second variable was never used anywhere, so I believe it is safe to remove it. I don't understand why the util variable is necessary at all as substituting api.lib.util everywhere seems to work just fine and makes it clear what util refers to.