### PR TITLE
Auto guess slide title from first non-blank line

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -2030,6 +2030,10 @@
 
     const SLIDE_SEPARATOR = /^-----$/m;
 
+    // Max length for title.
+    // Line longer than this won't be used as title
+    const MAX_TITLE_LEN = 40;
+
     const getMarkdownParser = function( ) {
         if ( window.hasOwnProperty( "marked" ) ) {
 
@@ -2060,6 +2064,21 @@
         }
 
         return text.split( SLIDE_SEPARATOR );
+    };
+
+    const guessSlideTitle = function( text ) {
+        for ( var line of text.split( "\n" ) ) {
+            line = line.trim( );
+            if ( line.length > 0 ) {
+                if ( line.length <= MAX_TITLE_LEN ) {
+                    return line;
+                }
+
+                // The first non-blank is too long to be a title
+                return "";
+            }
+        }
+        return "";
     };
 
     const convertMarkdowns = function( selector ) {
@@ -2101,8 +2120,14 @@
                 slideElems[ i ].innerHTML =
                     parseMarkdown( slideElems[ i ], slides[ i ] );
 
+                // Set the slide title.
+                // The first slide will use original title if exists.
+                var title = guessSlideTitle( slideElems[ i ].innerText );
+
                 if ( origTitle && ( i === 0 ) ) {
                     slideElems[ i ].title = origTitle;
+                } else if ( title ) {
+                    slideElems[ i ].title = title;
                 }
             }
         }

--- a/js/impress.js
+++ b/js/impress.js
@@ -2031,7 +2031,7 @@
     const SLIDE_SEPARATOR = /^-----$/m;
 
     // Max length for title.
-    // Line longer than this won't be used as title
+    // Line longer than this will be cutted.
     const MAX_TITLE_LEN = 40;
 
     const getMarkdownParser = function( ) {
@@ -2072,10 +2072,9 @@
             if ( line.length > 0 ) {
                 if ( line.length <= MAX_TITLE_LEN ) {
                     return line;
+                } else {
+                    return line.slice( 0, MAX_TITLE_LEN - 3 ) + "...";
                 }
-
-                // The first non-blank is too long to be a title
-                return "";
             }
         }
         return "";

--- a/js/impress.js
+++ b/js/impress.js
@@ -2030,10 +2030,6 @@
 
     const SLIDE_SEPARATOR = /^-----$/m;
 
-    // Max length for title.
-    // Line longer than this will be cutted.
-    const MAX_TITLE_LEN = 40;
-
     const getMarkdownParser = function( ) {
         if ( window.hasOwnProperty( "marked" ) ) {
 
@@ -2064,20 +2060,6 @@
         }
 
         return text.split( SLIDE_SEPARATOR );
-    };
-
-    const guessSlideTitle = function( text ) {
-        for ( var line of text.split( "\n" ) ) {
-            line = line.trim( );
-            if ( line.length > 0 ) {
-                if ( line.length <= MAX_TITLE_LEN ) {
-                    return line;
-                } else {
-                    return line.slice( 0, MAX_TITLE_LEN - 3 ) + "...";
-                }
-            }
-        }
-        return "";
     };
 
     const convertMarkdowns = function( selector ) {
@@ -2119,14 +2101,8 @@
                 slideElems[ i ].innerHTML =
                     parseMarkdown( slideElems[ i ], slides[ i ] );
 
-                // Set the slide title.
-                // The first slide will use original title if exists.
-                var title = guessSlideTitle( slideElems[ i ].innerText );
-
                 if ( origTitle && ( i === 0 ) ) {
                     slideElems[ i ].title = origTitle;
-                } else if ( title ) {
-                    slideElems[ i ].title = title;
                 }
             }
         }
@@ -3976,6 +3952,33 @@
         return tempDiv.firstChild;
     };
 
+    var getStepTitle = function( step ) {
+
+        // Max length for title.
+        // Line longer than this will be cutted.
+        const MAX_TITLE_LEN = 40;
+
+        if ( step.title ) {
+            return step.title;
+        }
+
+        // Neither title nor id is defined
+        if ( step.id.startsWith( 'step-' ) ) {
+            for ( var line of step.innerText.split( '\n' ) ) {
+                line = line.trim( );
+                if ( line.length > 0 ) {
+                    if ( line.length <= MAX_TITLE_LEN ) {
+                        return line;
+                    } else {
+                        return line.slice( 0, MAX_TITLE_LEN - 3 ) + '...';
+                    }
+                }
+            }
+        }
+
+        return step.id;
+    };
+
     var selectOptionsHtml = function() {
         var options = '';
         for ( var i = 0; i < steps.length; i++ ) {
@@ -3984,7 +3987,7 @@
             if ( hideSteps.indexOf( steps[ i ] ) < 0 ) {
                 options = options + '<option value="' + steps[ i ].id + '">' + // jshint ignore:line
 							(
-								steps[ i ].title ? steps[ i ].title : steps[ i ].id
+								getStepTitle( steps[ i ] )
 							) + '</option>' + '\n';
             }
         }

--- a/src/plugins/extras/extras.js
+++ b/src/plugins/extras/extras.js
@@ -17,7 +17,7 @@
     const SLIDE_SEPARATOR = /^-----$/m;
 
     // Max length for title.
-    // Line longer than this won't be used as title
+    // Line longer than this will be cutted.
     const MAX_TITLE_LEN = 40;
 
     const getMarkdownParser = function( ) {
@@ -58,10 +58,9 @@
             if ( line.length > 0 ) {
                 if ( line.length <= MAX_TITLE_LEN ) {
                     return line;
+                } else {
+                    return line.slice( 0, MAX_TITLE_LEN - 3 ) + "...";
                 }
-
-                // The first non-blank is too long to be a title
-                return "";
             }
         }
         return "";

--- a/src/plugins/extras/extras.js
+++ b/src/plugins/extras/extras.js
@@ -16,6 +16,10 @@
 
     const SLIDE_SEPARATOR = /^-----$/m;
 
+    // Max length for title.
+    // Line longer than this won't be used as title
+    const MAX_TITLE_LEN = 40;
+
     const getMarkdownParser = function( ) {
         if ( window.hasOwnProperty( "marked" ) ) {
 
@@ -46,6 +50,21 @@
         }
 
         return text.split( SLIDE_SEPARATOR );
+    };
+
+    const guessSlideTitle = function( text ) {
+        for ( var line of text.split( "\n" ) ) {
+            line = line.trim( );
+            if ( line.length > 0 ) {
+                if ( line.length <= MAX_TITLE_LEN ) {
+                    return line;
+                }
+
+                // The first non-blank is too long to be a title
+                return "";
+            }
+        }
+        return "";
     };
 
     const convertMarkdowns = function( selector ) {
@@ -87,8 +106,14 @@
                 slideElems[ i ].innerHTML =
                     parseMarkdown( slideElems[ i ], slides[ i ] );
 
+                // Set the slide title.
+                // The first slide will use original title if exists.
+                var title = guessSlideTitle( slideElems[ i ].innerText );
+
                 if ( origTitle && ( i === 0 ) ) {
                     slideElems[ i ].title = origTitle;
+                } else if ( title ) {
+                    slideElems[ i ].title = title;
                 }
             }
         }

--- a/src/plugins/extras/extras.js
+++ b/src/plugins/extras/extras.js
@@ -16,10 +16,6 @@
 
     const SLIDE_SEPARATOR = /^-----$/m;
 
-    // Max length for title.
-    // Line longer than this will be cutted.
-    const MAX_TITLE_LEN = 40;
-
     const getMarkdownParser = function( ) {
         if ( window.hasOwnProperty( "marked" ) ) {
 
@@ -50,20 +46,6 @@
         }
 
         return text.split( SLIDE_SEPARATOR );
-    };
-
-    const guessSlideTitle = function( text ) {
-        for ( var line of text.split( "\n" ) ) {
-            line = line.trim( );
-            if ( line.length > 0 ) {
-                if ( line.length <= MAX_TITLE_LEN ) {
-                    return line;
-                } else {
-                    return line.slice( 0, MAX_TITLE_LEN - 3 ) + "...";
-                }
-            }
-        }
-        return "";
     };
 
     const convertMarkdowns = function( selector ) {
@@ -105,14 +87,8 @@
                 slideElems[ i ].innerHTML =
                     parseMarkdown( slideElems[ i ], slides[ i ] );
 
-                // Set the slide title.
-                // The first slide will use original title if exists.
-                var title = guessSlideTitle( slideElems[ i ].innerText );
-
                 if ( origTitle && ( i === 0 ) ) {
                     slideElems[ i ].title = origTitle;
-                } else if ( title ) {
-                    slideElems[ i ].title = title;
                 }
             }
         }

--- a/src/plugins/navigation-ui/navigation-ui.js
+++ b/src/plugins/navigation-ui/navigation-ui.js
@@ -38,6 +38,33 @@
         return tempDiv.firstChild;
     };
 
+    var getStepTitle = function( step ) {
+
+        // Max length for title.
+        // Line longer than this will be cutted.
+        const MAX_TITLE_LEN = 40;
+
+        if ( step.title ) {
+            return step.title;
+        }
+
+        // Neither title nor id is defined
+        if ( step.id.startsWith( 'step-' ) ) {
+            for ( var line of step.innerText.split( '\n' ) ) {
+                line = line.trim( );
+                if ( line.length > 0 ) {
+                    if ( line.length <= MAX_TITLE_LEN ) {
+                        return line;
+                    } else {
+                        return line.slice( 0, MAX_TITLE_LEN - 3 ) + '...';
+                    }
+                }
+            }
+        }
+
+        return step.id;
+    };
+
     var selectOptionsHtml = function() {
         var options = '';
         for ( var i = 0; i < steps.length; i++ ) {
@@ -46,7 +73,7 @@
             if ( hideSteps.indexOf( steps[ i ] ) < 0 ) {
                 options = options + '<option value="' + steps[ i ].id + '">' + // jshint ignore:line
 							(
-								steps[ i ].title ? steps[ i ].title : steps[ i ].id
+								getStepTitle( steps[ i ] )
 							) + '</option>' + '\n';
             }
         }


### PR DESCRIPTION
Markdown slides can be split into multiple slides by `-----`, but currently there's not way to set slide for slides other than the first one.  What this PR does is:

- If a  markdown step has title, use it for the first slide
- Otherwise use the first non-blank line as title for each splited slides

It should make slide navigation easier by a meaningful title. 