### PR TITLE
Fix incorrect tag in 3D-positions example

### DIFF
--- a/examples/3D-positions/index.html
+++ b/examples/3D-positions/index.html
@@ -166,4 +166,4 @@
     <script type="text/javascript" src="../../js/impress.js"></script>
     <script>impress().init();</script>
   </body>
-<html>
+</html>


### PR DESCRIPTION
Change `<html>` to `</html>`.
Thanks kuninori.morimoto.gx@renesas.com to point out this. 