### PR TITLE
Allow multiple data-substep-order with the same value

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -4692,14 +4692,19 @@
                 substeps[ i ].classList.remove( "substep-active" );
             }
 
+            // Loop over all substeps that are not yet visible and set
+            //   those of currentSubstepOrder to visible and active
             var el;
-            var curr;
+            var currentSubstepOrder;
             for ( var j = visible.length; j < substeps.length; j++ ) {
-                if ( curr && curr !== substeps[ j ].dataset.substepOrder ) {
+                if ( currentSubstepOrder &&
+                    currentSubstepOrder !== substeps[ j ].dataset.substepOrder ) {
+
+                    // Stop if the substepOrder is greater
                     break;
                 }
                 el = substeps[ j ];
-                curr = el.dataset.substepOrder;
+                currentSubstepOrder = el.dataset.substepOrder;
                 el.classList.add( "substep-visible" );
                 el.classList.add( "substep-active" );
             }
@@ -4731,6 +4736,8 @@
             }
             var el = visible[ visible.length - 1 ];
             el.classList.remove( "substep-visible" );
+
+            // Continue if there is another substep with the same substepOrder
             if ( current > 0 &&
                 visible[ current - 1 ].dataset.substepOrder ===
                 visible[ current ].dataset.substepOrder ) {

--- a/js/impress.js
+++ b/js/impress.js
@@ -4691,9 +4691,19 @@
             for ( var i = 0; i < substeps.length; i++ ) {
                 substeps[ i ].classList.remove( "substep-active" );
             }
-            var el = substeps[ visible.length ];
-            el.classList.add( "substep-visible" );
-            el.classList.add( "substep-active" );
+
+            var el;
+            var curr;
+            for ( var j = visible.length; j < substeps.length; j++ ) {
+                if ( curr && curr !== substeps[ j ].dataset.substepOrder ) {
+                    break;
+                }
+                el = substeps[ j ];
+                curr = el.dataset.substepOrder;
+                el.classList.add( "substep-visible" );
+                el.classList.add( "substep-active" );
+            }
+
             return el;
         }
     };
@@ -4721,6 +4731,12 @@
             }
             var el = visible[ visible.length - 1 ];
             el.classList.remove( "substep-visible" );
+            if ( current > 0 &&
+                visible[ current - 1 ].dataset.substepOrder ===
+                visible[ current ].dataset.substepOrder ) {
+                visible.pop();
+                return hideSubstep( visible );
+            }
             return el;
         }
     };

--- a/src/plugins/substep/substep.js
+++ b/src/plugins/substep/substep.js
@@ -89,14 +89,19 @@
                 substeps[ i ].classList.remove( "substep-active" );
             }
 
+            // Loop over all substeps that are not yet visible and set
+            //   those of currentSubstepOrder to visible and active
             var el;
-            var curr;
+            var currentSubstepOrder;
             for ( var j = visible.length; j < substeps.length; j++ ) {
-                if ( curr && curr !== substeps[ j ].dataset.substepOrder ) {
+                if ( currentSubstepOrder &&
+                    currentSubstepOrder !== substeps[ j ].dataset.substepOrder ) {
+
+                    // Stop if the substepOrder is greater
                     break;
                 }
                 el = substeps[ j ];
-                curr = el.dataset.substepOrder;
+                currentSubstepOrder = el.dataset.substepOrder;
                 el.classList.add( "substep-visible" );
                 el.classList.add( "substep-active" );
             }
@@ -128,6 +133,8 @@
             }
             var el = visible[ visible.length - 1 ];
             el.classList.remove( "substep-visible" );
+
+            // Continue if there is another substep with the same substepOrder
             if ( current > 0 &&
                 visible[ current - 1 ].dataset.substepOrder ===
                 visible[ current ].dataset.substepOrder ) {

--- a/src/plugins/substep/substep.js
+++ b/src/plugins/substep/substep.js
@@ -88,9 +88,19 @@
             for ( var i = 0; i < substeps.length; i++ ) {
                 substeps[ i ].classList.remove( "substep-active" );
             }
-            var el = substeps[ visible.length ];
-            el.classList.add( "substep-visible" );
-            el.classList.add( "substep-active" );
+
+            var el;
+            var curr;
+            for ( var j = visible.length; j < substeps.length; j++ ) {
+                if ( curr && curr !== substeps[ j ].dataset.substepOrder ) {
+                    break;
+                }
+                el = substeps[ j ];
+                curr = el.dataset.substepOrder;
+                el.classList.add( "substep-visible" );
+                el.classList.add( "substep-active" );
+            }
+
             return el;
         }
     };
@@ -118,6 +128,12 @@
             }
             var el = visible[ visible.length - 1 ];
             el.classList.remove( "substep-visible" );
+            if ( current > 0 &&
+                visible[ current - 1 ].dataset.substepOrder ===
+                visible[ current ].dataset.substepOrder ) {
+                visible.pop();
+                return hideSubstep( visible );
+            }
             return el;
         }
     };


### PR DESCRIPTION
In #779, the ability to add the order of substeps using the `data-substep-order` has been added. The current implementation relies on the assumption that all the given numbers are unique: a sequence `1, 2, 10, 100` is correctly handled, but another `1, 1, 2, 2`  is not. I find the latter very useful to show multiple elements of different DOM nodes in a single substep.

Take for instance a slightly modified version of @codesections' original example from https://github.com/impress/impress.js/pull/779#issuecomment-774574325.

```html
 <ul>
     <li class="substep"  data-substep-order="0">
         TypeScript <span class="substep" data-substep-order="3">(Microsoft)</span>
     </li>
     <li class="substep"  data-substep-order="1">
         Golang <span class="substep" data-substep-order="3">(Google)</span>
     </li>
     <li class="substep data-substep-order="2">
         Rust<span class="substep" data-substep-order="3">(Mozilla et al.)</span>
     </li>
 </ul>
```

In contrast to the original example, the examples are shown in a single, last substep.

This PR adds the correct handling of multiple `data-substep-order` with the same value. I don't think it needs to be explicitly stated in the plugin's README – as I originally thought it would already be supported :) 

A real-world example that uses the proposed change can be found at [multiple](https://nogatz.net/talks/202210_phd-defense/#/Flexible-Syntax) [occasions](https://nogatz.net/talks/202210_phd-defense/#/DSLs-with-Prolog) in the slides of my PhD defense ([source code](https://github.com/fnogatz/talks/tree/gh-pages/202210_phd-defense)).