### PR TITLE
Add .slideView or .preView class if loaded in console

### DIFF
--- a/css/impress-common.css
+++ b/css/impress-common.css
@@ -94,6 +94,23 @@ It is focused on plugin functionality, not the visual style of your presentation
 }
 
 /*
+  We might want to hide the help, toolbar, progress and progress bar in the
+  preView window of the impressConsole that is displayed when you press P.
+*/
+.impress-console.preView .impress-progress,
+.impress-console.preView .impress-progressbar,
+.impress-console.preView #impress-toolbar,
+.impress-console.preView #impress-help {
+  display: none;
+}
+/*
+  Hide the help in the slideView as well.
+*/
+.impress-console.slideView #impress-help {
+  display: none;
+}
+
+/*
     With help from the mouse-timeout plugin, we can hide the toolbar and
     have it show only when you move/click/touch the mouse.
 */

--- a/js/impress.js
+++ b/js/impress.js
@@ -2891,8 +2891,8 @@
                 var preView = consoleWindow.document.getElementById( 'preView' );
 
                 // Firefox:
-                slideView.contentDocument.body.classList.add( 'impress-console' );
-                preView.contentDocument.body.classList.add( 'impress-console' );
+                slideView.contentDocument.body.classList.add( 'impress-console', 'slideView' );
+                preView.contentDocument.body.classList.add( 'impress-console', 'preView' );
                 if ( cssFileIframe !== undefined ) {
                     slideView.contentDocument.head.insertAdjacentHTML(
                         'beforeend',
@@ -2906,7 +2906,8 @@
 
                 // Chrome:
                 slideView.addEventListener( 'load', function() {
-                        slideView.contentDocument.body.classList.add( 'impress-console' );
+                        slideView.contentDocument.body.classList.add( 'impress-console',
+                            'slideView' );
                         if ( cssFileIframe !== undefined ) {
                             slideView.contentDocument.head.insertAdjacentHTML(
                                 'beforeend',
@@ -2916,7 +2917,7 @@
                         }
                 } );
                 preView.addEventListener( 'load', function() {
-                        preView.contentDocument.body.classList.add( 'impress-console' );
+                        preView.contentDocument.body.classList.add( 'impress-console', 'preView' );
                         if ( cssFileIframe !== undefined ) {
                             preView.contentDocument.head.insertAdjacentHTML(
                                 'beforeend',

--- a/src/plugins/impressConsole/impressConsole.js
+++ b/src/plugins/impressConsole/impressConsole.js
@@ -342,8 +342,8 @@
                 var preView = consoleWindow.document.getElementById( 'preView' );
 
                 // Firefox:
-                slideView.contentDocument.body.classList.add( 'impress-console' );
-                preView.contentDocument.body.classList.add( 'impress-console' );
+                slideView.contentDocument.body.classList.add( 'impress-console', 'slideView' );
+                preView.contentDocument.body.classList.add( 'impress-console', 'preView' );
                 if ( cssFileIframe !== undefined ) {
                     slideView.contentDocument.head.insertAdjacentHTML(
                         'beforeend',
@@ -357,7 +357,7 @@
 
                 // Chrome:
                 slideView.addEventListener( 'load', function() {
-                        slideView.contentDocument.body.classList.add( 'impress-console' );
+                        slideView.contentDocument.body.classList.add( 'impress-console', 'slideView' );
                         if ( cssFileIframe !== undefined ) {
                             slideView.contentDocument.head.insertAdjacentHTML(
                                 'beforeend',
@@ -367,7 +367,7 @@
                         }
                 } );
                 preView.addEventListener( 'load', function() {
-                        preView.contentDocument.body.classList.add( 'impress-console' );
+                        preView.contentDocument.body.classList.add( 'impress-console', 'preView' );
                         if ( cssFileIframe !== undefined ) {
                             preView.contentDocument.head.insertAdjacentHTML(
                                 'beforeend',

--- a/src/plugins/impressConsole/impressConsole.js
+++ b/src/plugins/impressConsole/impressConsole.js
@@ -357,7 +357,8 @@
 
                 // Chrome:
                 slideView.addEventListener( 'load', function() {
-                        slideView.contentDocument.body.classList.add( 'impress-console', 'slideView' );
+                        slideView.contentDocument.body.classList.add( 'impress-console',
+                            'slideView' );
                         if ( cssFileIframe !== undefined ) {
                             slideView.contentDocument.head.insertAdjacentHTML(
                                 'beforeend',


### PR DESCRIPTION
The impress console is a really useful tool for presenters. As of now, it is however not possible to change the slide's style only for the *slideView* (current slide) or only for the *preView* (next slide). We can't use CSS here as it is not aware of the fact if the page is loaded in an iframe.

The `impressConsole.js` already dynamically adds the class `impress-console` to the body of both iframes. This PR additionally adds the `slideView` and `preView` class, respectively. As a result, we can for instance hide the progress, progressbar and toolbar only in the *preView* using the following CSS snippet:

```css
.impress-console.preView .impress-progress,
.impress-console.preView .impress-progressbar,
.impress-console.preView #impress-toolbar {
  display: none;
}
```

A real-world example that uses the proposed change can be found in the slides' console of my [PhD defense](https://nogatz.net/talks/202210_phd-defense/) ([source code](https://github.com/fnogatz/talks/tree/gh-pages/202210_phd-defense)).