### PR TITLE
Highlight future substeps in slideView

### DIFF
--- a/css/impress-common.css
+++ b/css/impress-common.css
@@ -111,6 +111,42 @@ It is focused on plugin functionality, not the visual style of your presentation
 }
 
 /*
+  Highlight substeps that are not yet visible in the sliveView window of the
+  impressConsole.
+*/
+.impress-console.slideView #impress .step:not(.future) .substep:not(.substep-visible) {
+  position: relative;
+  opacity: 1.0;
+}
+.impress-console.slideView #impress .step:not(.future) .substep:not(.substep-visible):before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(100% - 10px);
+  height: calc(100% - 10px);
+  content: "";
+  border: 5px solid red;
+}
+.impress-console.slideView #impress .step:not(.future) .substep:not(.substep-visible):after {
+  position: absolute;
+  height: 60px;
+  width: 60px;
+  left: -30px;
+  top: -30px;
+  font-size: 40px;
+  text-align: center;
+  background-color: red;
+  color: #fff;
+  font-weight: bold;
+  content: "1";
+  border-radius: 30px;
+  padding: 0;
+}
+.impress-console.slideView #impress .step:not(.future) .substep[data-substep-order]:not(.substep-visible):after {
+  content: attr(data-substep-order);
+}
+
+/*
     With help from the mouse-timeout plugin, we can hide the toolbar and
     have it show only when you move/click/touch the mouse.
 */

--- a/css/impress-common.css
+++ b/css/impress-common.css
@@ -127,7 +127,7 @@ It is focused on plugin functionality, not the visual style of your presentation
   content: "";
   border: 5px solid red;
 }
-.impress-console.slideView #impress .step:not(.future) .substep:not(.substep-visible):after {
+.impress-console.slideView #impress .step:not(.future):has(.substep[data-substep-order]) .substep:not(.substep-visible):after {
   position: absolute;
   height: 60px;
   width: 60px;
@@ -142,7 +142,7 @@ It is focused on plugin functionality, not the visual style of your presentation
   border-radius: 30px;
   padding: 0;
 }
-.impress-console.slideView #impress .step:not(.future) .substep[data-substep-order]:not(.substep-visible):after {
+.impress-console.slideView #impress .step:not(.future):has(.substep[data-substep-order]) .substep[data-substep-order]:not(.substep-visible):after {
   content: attr(data-substep-order);
 }
 


### PR DESCRIPTION
In the current version of impress.js, the *slideView* in the impress-console is an exact copy of the slide that is currently presented. In my opinion, this ignores one essential benefit of this view, namely to additionally give the presenter hints on what is coming next.

This PR adds a CSS snippet that indicates the next *substeps* by a red border:

![Screenshot from 2022-12-26 14-45-43](https://user-images.githubusercontent.com/881988/209555330-98bcc29c-cc2c-4c66-ade1-673959f4d5f4.png)

In addition, if at least one substep has the `data-substep-order` attribute set, the corresponding step number is displayed as well:

![Screenshot from 2022-12-26 14-46-53](https://user-images.githubusercontent.com/881988/209555415-4f29ce20-bc79-4c8a-a652-7a7ba1ac23ac.png)

The highlighting is removed once the substep is displayed:

![Screenshot from 2022-12-26 14-48-15](https://user-images.githubusercontent.com/881988/209555518-c7ac70c7-c3de-45ac-b429-19ed238a7798.png)

This PR is a follow-up on #825 and #827.