### PR TITLE
Fix default substep order when no explicit order given (#855)

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -8,7 +8,7 @@
  * in modern browsers and inspired by the idea behind prezi.com.
  *
  *
- * Copyright 2011-2012 Bartek Szopka (@bartaz), 2016-2023 Henrik Ingo (@henrikingo) 
+ * Copyright 2011-2012 Bartek Szopka (@bartaz), 2016-2023 Henrik Ingo (@henrikingo)
  * and 70+ other contributors
  *
  * Released under the MIT License.
@@ -4709,6 +4709,11 @@
                 currentSubstepOrder = el.dataset.substepOrder;
                 el.classList.add( "substep-visible" );
                 el.classList.add( "substep-active" );
+                if ( currentSubstepOrder === undefined ) {
+
+                    // Stop after one substep as default order
+                    break;
+                }
             }
 
             return el;
@@ -4741,6 +4746,7 @@
 
             // Continue if there is another substep with the same substepOrder
             if ( current > 0 &&
+                visible[ current ].dataset.substepOrder !== undefined &&
                 visible[ current - 1 ].dataset.substepOrder ===
                 visible[ current ].dataset.substepOrder ) {
                 visible.pop();

--- a/src/plugins/substep/substep.js
+++ b/src/plugins/substep/substep.js
@@ -104,6 +104,11 @@
                 currentSubstepOrder = el.dataset.substepOrder;
                 el.classList.add( "substep-visible" );
                 el.classList.add( "substep-active" );
+                if ( currentSubstepOrder === undefined ) {
+
+                    // Stop after one substep as default order
+                    break;
+                }
             }
 
             return el;
@@ -136,6 +141,7 @@
 
             // Continue if there is another substep with the same substepOrder
             if ( current > 0 &&
+                visible[ current ].dataset.substepOrder !== undefined &&
                 visible[ current - 1 ].dataset.substepOrder ===
                 visible[ current ].dataset.substepOrder ) {
                 visible.pop();


### PR DESCRIPTION
This PR fixes the default order of substeps, for which no explicit order was given (see issue #855). It ensures that the loop for marking substeps "active" + "visible" is left when at least one substep (with explicit or default order) was marked and this substep uses default order.

Note: The removed space in the header of js/impress.js does not relate to the current issue, but comes from regenerating this file. Apparently the file has not been regenerated when its source file was modified in some previous commit.