### PR TITLE
Fix HTML syntax in classic slides example

### DIFF
--- a/examples/classic-slides/index.html
+++ b/examples/classic-slides/index.html
@@ -325,7 +325,7 @@
           A(Support for<br />diagrams)
           B[Provided by<br />mermaid.js]
           C{Already<br />know<br />mermaid?}
-          D(<a href=&quot;http://knsv.github.io/mermaid/index.html#usage&quot;>Tutorial</a>)
+          D(Tutorial)
           E(Great, hope you enjoy!)
           A-->B
           B-->C

--- a/examples/classic-slides/index.html
+++ b/examples/classic-slides/index.html
@@ -338,7 +338,7 @@
         <h1><a href="http://docs.mathjax.org/en/latest/start.html">MathJax.js</a></h1>
         <p>Use \(\LaTeX\), MathML or AsciiMath to properly show mathematical formula.</p>
         <div class="notes">
-          Mermaid.js, likewise in a href="https://github.com/impress/impress.js/tree/master/extras">extras/</a>
+          Mermaid.js, likewise in <a href="https://github.com/impress/impress.js/tree/master/extras">extras/</a>
            directory, draws SVG diagrams from a MarkDown-like syntax. To learn
           more about it <a href="http://knsv.github.io/mermaid/index.html#usage">read the fine manual</a>.
         </div>


### PR DESCRIPTION
The current HTML in `examples/classic-slides/index.html` is invalid syntax. This PR fixes the two problems.

In 81b49d0ec250e4e4b7b49b381b26cdcf066447e2, I removed the link to the tutorial at all, since inline links are disabled by default since Mermaid.js v8.2.0: see 'click functionality is disabled' in their [release notes](https://github.com/mermaid-js/mermaid/releases/tag/8.2.0).