### PR TITLE
[WIP] Add three plugin

### DIFF
--- a/examples/three/index.html
+++ b/examples/three/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>impress.js with Three.js Plugin</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tween.js/23.1.3/tween.umd.js"></script>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+        #impress {
+            position: relative;
+        }
+        .step {
+            width: 900px;
+            height: 700px;
+            padding: 40px;
+            box-sizing: border-box;
+            font-family: Arial, sans-serif;
+        }
+        #impress-three-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+            pointer-events: none;
+        }
+        #css-grid {
+            width: 3000px;
+            height: 3000px;
+            display: grid;
+            grid-template-columns: repeat(10, 1fr);
+            grid-template-rows: repeat(10, 1fr);
+        }
+        
+        .grid-cell {
+            border: 1px solid rgba(0, 0, 0, 0.8);
+        }
+    </style>
+</head>
+<body class="impress-not-supported">
+    <div id="impress-three-container"></div>
+    <div id="impress">
+        <div class="step" data-x="0" data-y="-1000" data-z="0" data-rotate-x="90">
+            <h1>x-0</h1>
+            <h1>y--1000</h1>
+            <h1>rotate-x-90</h1>
+        </div>
+        <div class="step" data-x="0" data-y="0" data-z="0" data-rotate-y="90">
+            <h1>x-0</h1>
+            <h1>y-0</h1>
+            <h1>rotate-y-90</h1>
+        </div>
+        <div class="step" data-x="0" data-y="0" data-z="0" data-rotate-z="90">
+            <h1>x-0</h1>
+            <h1>y-0</h1>
+            <h1>rotate-z-90</h1>
+        </div>
+        <div class="step" data-x="0" data-y="0" data-z="0">
+            <h1>x-0</h1>
+            <h1>y-0</h1>
+        </div>
+        <div class="step" data-x="500" data-y="0" data-z="0">
+            <h1>x-500</h1>
+            <h1>y-0</h1>
+        </div>
+        <div class="step" data-x="500" data-y="500" data-z="0">
+            <h1>x-500</h1>
+            <h1>y-500</h1>
+        </div>
+        <div class="step" data-x="0" data-y="1000" data-z="0" data-rotate-y="90">
+            <h1>x-0</h1>
+            <h1>y-1000</h1>
+            <h1>rotate-y-90</h1>
+        </div>
+    </div>
+
+    <script src="../../src/impress.js"></script>
+    <script src="../../src/lib/gc.js"></script>
+    <script src="../../src/lib/util.js"></script>
+    <script src="../../src/lib/rotation.js"></script>
+    <script src="../../src/plugins/autoplay/autoplay.js"></script>
+    <script src="../../src/plugins/blackout/blackout.js"></script>
+    <script src="../../src/plugins/extras/extras.js"></script>
+    <script src="../../src/plugins/form/form.js"></script>
+    <script src="../../src/plugins/fullscreen/fullscreen.js"></script>
+    <script src="../../src/plugins/goto/goto.js"></script>
+    <script src="../../src/plugins/bookmark/bookmark.js"></script>
+    <script src="../../src/plugins/help/help.js"></script>
+    <script src="../../src/plugins/impressConsole/impressConsole.js"></script>
+    <script src="../../src/plugins/media/media.js"></script>
+    <script src="../../src/plugins/mobile/mobile.js"></script>
+    <script src="../../src/plugins/mouse-timeout/mouse-timeout.js"></script>
+    <script src="../../src/plugins/navigation/navigation.js"></script>
+    <script src="../../src/plugins/navigation-ui/navigation-ui.js"></script>
+    <script src="../../src/plugins/progress/progress.js"></script>
+    <script src="../../src/plugins/rel/rel.js"></script>
+    <script src="../../src/plugins/resize/resize.js"></script>
+    <script src="../../src/plugins/skip/skip.js"></script>
+    <script src="../../src/plugins/stop/stop.js"></script>
+    <script src="../../src/plugins/substep/substep.js"></script>
+    <script src="../../src/plugins/touch/touch.js"></script>
+    <script src="../../src/plugins/toolbar/toolbar.js"></script>
+    <script src="../../src/plugins/three/three.js"></script>
+    <script>impress().init();</script>
+</body>
+</html>

--- a/src/plugins/three/three.js
+++ b/src/plugins/three/three.js
@@ -1,0 +1,124 @@
+(function (document, window) {
+    'use strict';
+
+    var impressThreePlugin = function (root) {
+        var scene, camera, renderer;
+        var objects = [];
+        var impressScale = 1;
+        var fov = 75; // TODO: calc the correct fov
+        var currentTween;
+
+        function init() {
+            var threeContainer = document.getElementById('impress-three-container');
+
+            scene = new THREE.Scene();
+            camera = new THREE.PerspectiveCamera(fov, window.innerWidth / window.innerHeight, 0.1, 10000);
+            renderer = new THREE.WebGLRenderer({ alpha: true });
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            threeContainer.appendChild(renderer.domElement);
+
+            // TODO: just for dev, to be removed
+            addObjects();
+
+            requestAnimationFrame(animate);
+            window.addEventListener('resize', onWindowResize, false);
+        }
+
+        function addObjects() {
+            var gridHelper = new THREE.GridHelper(2000, 20);
+            scene.add(gridHelper);
+
+            for (var i = 0; i < 50; i++) {
+                var geometry = new THREE.BoxGeometry(50, 50, 50);
+                var material = new THREE.MeshBasicMaterial({ color: Math.random() * 0xffffff, wireframe: true });
+                var cube = new THREE.Mesh(geometry, material);
+                cube.position.set(
+                    Math.random() * 2000 - 1000,
+                    Math.random() * 2000 - 1000,
+                    Math.random() * 2000 - 1000
+                );
+                scene.add(cube);
+                objects.push(cube);
+            }
+        }
+
+        function animate(time) {
+            requestAnimationFrame(animate);
+
+            TWEEN.update(time);
+
+            renderer.render(scene, camera);
+        }
+
+        function onWindowResize() {
+            camera.aspect = window.innerWidth / window.innerHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(window.innerWidth, window.innerHeight);
+        }
+
+        function updateCamera(x, y, z, rotateX, rotateY, rotateZ) {
+            if (currentTween) {
+                currentTween.stop();
+            }
+        
+            const startPos = camera.position.clone();
+            const startRot = camera.rotation.clone();
+            
+            // Adjust coordinates for Three.js
+            var endPos = new THREE.Vector3(
+                x * impressScale,
+                -y * impressScale,
+                -z * impressScale
+            );
+            var endRot = new THREE.Euler(
+                THREE.MathUtils.degToRad(-rotateX),
+                THREE.MathUtils.degToRad(rotateY),
+                THREE.MathUtils.degToRad(-rotateZ)
+            );
+
+            var tweenObj = {
+                x: startPos.x, y: startPos.y, z: startPos.z,
+                rx: startRot.x, ry: startRot.y, rz: startRot.z
+            };
+
+            currentTween = new TWEEN.Tween(tweenObj)
+                .to({
+                    x: endPos.x, y: endPos.y, z: endPos.z,
+                    rx: endRot.x, ry: endRot.y, rz: endRot.z
+                }, 1000) // TODO: read from data-transition-duration
+                .easing(TWEEN.Easing.Cubic.InOut)
+                .onUpdate(() => {
+                    camera.position.set(tweenObj.x, tweenObj.y, tweenObj.z);
+                    camera.rotation.set(tweenObj.rx, tweenObj.ry, tweenObj.rz);
+                })
+                .start();
+        }
+
+        function updateCameraFromStep(step) {
+            var x = Number(step.dataset['x'] || 0);
+            var y = Number(step.dataset['y'] || 0);
+            var z = Number(step.dataset['z'] || 0);
+            var rotateX = Number(step.dataset['rotateX'] || 0);
+            var rotateY = Number(step.dataset['rotateY'] || 0);
+            var rotateZ = Number(step.dataset['rotateZ'] || 0);
+
+            updateCamera(x, y, z, rotateX, rotateY, rotateZ);
+        }
+
+        init();
+
+        document.addEventListener("impress:stepleave", function (event) {
+            // TODO: latency exists, consider a better solution
+            // Or maybe it's beacouse of easing function?
+            var nextStep = event.detail.next;
+            updateCameraFromStep(nextStep);
+        });
+
+        return {
+            updateCamera: updateCamera
+        };
+    };
+
+    impress.addPreInitPlugin(impressThreePlugin);
+
+})(document, window);


### PR DESCRIPTION
## Introduction

It's a plugin makes three.js works with impress.js, which allows like 3d models to be added in impress.js canvas with all other feat from three.js.

**This plugin is still in a very early stage, please do not merge.** It's a cool feat for me, but I'm not sure if it's suitable for impess.js, so I opened this pr for further discution. The features are not fully implemented yet, but I've wrote a simple example in `examples/three/index.html`.

## TODO

- [ ] Support to add 3d models by defining data sets.
- [ ] Add util functions to allow users to control the 3d models programmatically.

## Issues

- As it's depend on three.js and tween.js, I'm not sure if it's ok for impress.js.
- How should plugin add the three.js canvas overlay into the dom?
  - It's currently implemented by adding a div#impress-three-container manually, maybe better to insert the canvas in plugin initialization with the root dom?
- As it's depend on three.js and tween.js, I'm not sure if it's ok for impress.js.
- The three.js overlay is always on the top of impress canvas, this could be wrong in position.
  - We could try creating a separate canvas for each 3d models and move with dom.
- The animation is not fully synced with css animation.

## Ending

Here's still a lot not mentioned above, and I think here could be a lot changes to be made in impress.js, so I choose to contact you guys as early as possible to make it right. Or if this is plugin not what impress.js wanted, it's ok to reject and close this pr.