### PR TITLE
docs(toolbar): document element param instead of html

### DIFF
--- a/src/plugins/toolbar/toolbar.js
+++ b/src/plugins/toolbar/toolbar.js
@@ -43,14 +43,11 @@
  *
  *    { group : 1,                       // integer. Widgets with the same group are grouped inside
  *                                       // the same <span> element.
- *      html : "<button>Click</button>", // The html to add.
- *      callback : "mycallback",         // Toolbar plugin will trigger event
- *                                       // `impress:toolbar:added:mycallback` when done.
+ *      element : buttonElement,         // The DOM element to add to the toolbar.
  *      before: element }                // The reference element for an insertBefore() call.
  *
- * You should also listen to the `impress:toolbar:added:mycallback` event. At
- * this point you can find the new widget in the DOM, and for example add an
- * event listener to it.
+ * After the event is handled, the widget is already in the DOM, so you can
+ * attach event listeners to it immediately (see navigation-ui for an example).
  *
  * You are free to use any integer for the group. It's ok to leave gaps. It's
  * ok to co-locate with widgets for another plugin, if you think they belong


### PR DESCRIPTION
## Summary
- Update the toolbar plugin header docs to use `detail.element` (a DOM node), matching the implementation and `navigation-ui`.
- Remove the outdated `html` / `callback` / `impress:toolbar:added` guidance, since that event is never fired.

Fixes #771.

## Test plan
- [ ] Read `src/plugins/toolbar/toolbar.js` header and confirm it matches `appendChild` / `insertBefore` listeners
- [ ] Cross-check against `navigation-ui.js` toolbar usage